### PR TITLE
[DM-32423] Fix enabling of auto-merge for new PR

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change log
 ##########
 
+0.3.2 (2021-11-08)
+==================
+
+- Fix enabling of auto-merge after creating a new PR.
+- Update pinned dependencies.
+
 0.3.1 (2021-11-01)
 ==================
 

--- a/src/neophile/pr.py
+++ b/src/neophile/pr.py
@@ -190,7 +190,7 @@ class PullRequester:
             url_vars={"owner": github_repo.owner, "repo": github_repo.repo},
             data=data,
         )
-        await self._enable_auto_merge(github_repo, str(response["id"]))
+        await self._enable_auto_merge(github_repo, str(response["number"]))
 
     async def _enable_auto_merge(
         self, github_repo: GitHubRepository, pr_number: str
@@ -207,14 +207,14 @@ class PullRequester:
         # Enabling auto-merge is only available via the GraphQL API with a
         # mutation.  To use that, we have to retrieve the GraphQL ID of the PR
         # we just created, and then send the mutation.
-        response = await self._github.graphql(
-            _GRAPHQL_PR_ID,
-            owner=github_repo.owner,
-            repo=github_repo.repo,
-            pr_number=int(pr_number),
-        )
-        pr_id = response["repository"]["pullRequest"]["id"]
         try:
+            response = await self._github.graphql(
+                _GRAPHQL_PR_ID,
+                owner=github_repo.owner,
+                repo=github_repo.repo,
+                pr_number=int(pr_number),
+            )
+            pr_id = response["repository"]["pullRequest"]["id"]
             response = await self._github.graphql(
                 _GRAPHQL_ENABLE_AUTO_MERGE, pr_id=pr_id
             )

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -166,7 +166,7 @@ def test_analyze_pr(tmp_path: Path, mock_push: Mock) -> None:
 
         nonlocal created_pr
         created_pr = True
-        return CallbackResult(status=201, payload={"id": 42})
+        return CallbackResult(status=201, payload={"number": 42})
 
     with aioresponses() as mock:
         mock.get("https://lsst-sqre.github.io/charts/index.yaml", body=sqre)

--- a/tests/pr_test.py
+++ b/tests/pr_test.py
@@ -67,7 +67,7 @@ async def test_pr(
         mock_responses.get(pattern, payload=[])
         mock_responses.post(
             "https://api.github.com/repos/foo/bar/pulls",
-            payload={"id": 1},
+            payload={"number": 1},
             status=201,
         )
         mock_enable_auto_merge(mock_responses, "foo", "bar", "1")
@@ -155,7 +155,7 @@ async def test_pr_no_automerge(
         mock_responses.get(pattern, payload=[])
         mock_responses.post(
             "https://api.github.com/repos/foo/bar/pulls",
-            payload={"id": 1},
+            payload={"number": 1},
             status=201,
         )
         mock_enable_auto_merge(mock_responses, "foo", "bar", "1", fail=True)

--- a/tests/processor_test.py
+++ b/tests/processor_test.py
@@ -119,7 +119,7 @@ async def test_processor(tmp_path: Path, session: ClientSession) -> None:
 
         nonlocal created_pr
         created_pr = True
-        return CallbackResult(status=201, payload={"id": 42})
+        return CallbackResult(status=201, payload={"number": 42})
 
     with aioresponses() as mock:
         register_mock_github_tags(mock, "ambv", "black", ["20.0.0", "19.10b0"])
@@ -218,7 +218,7 @@ async def test_allow_expressions(
 
         nonlocal created_pr
         created_pr = True
-        return CallbackResult(status=201, payload={"id": 42})
+        return CallbackResult(status=201, payload={"number": 42})
 
     with aioresponses() as mock:
         register_mock_helm_repository(


### PR DESCRIPTION
The code to enable auto-merge was using the wrong field from the
return value of creating a new PR.  Use the number field instead
of the id field to get the PR number.

Update pinned dependencies.