### PR TITLE
DM-39519: Use relative imports and no TYPE_CHECKING

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
-docs/api/
+docs/dev/internals/
 docs/_static/*.png
 
 # PyBuilder

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -29,6 +29,7 @@ nitpick_ignore = [
     ["py:class", "pydantic.utils.Representation"],
     ["py:exc", "ruamel.yaml.YAMLError"],
 ]
+python_api_dir = "dev/internals"
 rst_epilog_file = "_rst_epilog.rst"
 
 [sphinx.intersphinx.projects]

--- a/src/neophile/analysis/base.py
+++ b/src/neophile/analysis/base.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from neophile.update.base import Update
+from ..update.base import Update
 
 __all__ = ["BaseAnalyzer"]
 

--- a/src/neophile/analysis/helm.py
+++ b/src/neophile/analysis/helm.py
@@ -3,16 +3,13 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 
-from neophile.analysis.base import BaseAnalyzer
-from neophile.inventory.version import SemanticVersion
-from neophile.update.helm import HelmUpdate
-
-if TYPE_CHECKING:
-    from neophile.inventory.helm import HelmInventory
-    from neophile.scanner.helm import HelmScanner
-    from neophile.update.base import Update
+from ..inventory.helm import HelmInventory
+from ..inventory.version import SemanticVersion
+from ..scanner.helm import HelmScanner
+from ..update.base import Update
+from ..update.helm import HelmUpdate
+from .base import BaseAnalyzer
 
 __all__ = ["HelmAnalyzer"]
 

--- a/src/neophile/analysis/kustomize.py
+++ b/src/neophile/analysis/kustomize.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from neophile.analysis.base import BaseAnalyzer
-from neophile.update.kustomize import KustomizeUpdate
-
-if TYPE_CHECKING:
-    from neophile.inventory.github import GitHubInventory
-    from neophile.scanner.kustomize import KustomizeScanner
-    from neophile.update.base import Update
+from ..inventory.github import GitHubInventory
+from ..scanner.kustomize import KustomizeScanner
+from ..update.base import Update
+from ..update.kustomize import KustomizeUpdate
+from .base import BaseAnalyzer
 
 __all__ = ["KustomizeAnalyzer"]
 

--- a/src/neophile/analysis/pre_commit.py
+++ b/src/neophile/analysis/pre_commit.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from neophile.analysis.base import BaseAnalyzer
-from neophile.update.pre_commit import PreCommitUpdate
-
-if TYPE_CHECKING:
-    from neophile.inventory.github import GitHubInventory
-    from neophile.scanner.pre_commit import PreCommitScanner
-    from neophile.update.base import Update
+from ..inventory.github import GitHubInventory
+from ..scanner.pre_commit import PreCommitScanner
+from ..update.base import Update
+from ..update.pre_commit import PreCommitUpdate
+from .base import BaseAnalyzer
 
 __all__ = ["PreCommitAnalyzer"]
 

--- a/src/neophile/analysis/python.py
+++ b/src/neophile/analysis/python.py
@@ -4,19 +4,15 @@ from __future__ import annotations
 
 import logging
 import subprocess
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 from git.repo import Repo
 
-from neophile.analysis.base import BaseAnalyzer
-from neophile.exceptions import UncommittedChangesError
-from neophile.update.python import PythonFrozenUpdate
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from neophile.update.base import Update
-    from neophile.virtualenv import VirtualEnv
+from ..exceptions import UncommittedChangesError
+from ..update.base import Update
+from ..update.python import PythonFrozenUpdate
+from ..virtualenv import VirtualEnv
+from .base import BaseAnalyzer
 
 __all__ = ["PythonAnalyzer"]
 

--- a/src/neophile/cli.py
+++ b/src/neophile/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any
 
 import aiohttp
 import click
@@ -12,12 +12,10 @@ from ruamel.yaml import YAML
 from safir.asyncio import run_with_asyncio
 from xdg import XDG_CONFIG_HOME
 
-from neophile.config import Configuration
-from neophile.factory import Factory
-from neophile.inventory.github import GitHubInventory
-
-if TYPE_CHECKING:
-    from typing import Any
+from .config import Configuration
+from .factory import Factory
+from .inventory.github import GitHubInventory
+from .processor import Processor
 
 __all__ = ["main"]
 
@@ -105,7 +103,7 @@ async def analyze(
 
     async with aiohttp.ClientSession() as session:
         factory = Factory(config, session)
-        processor = factory.create_processor()
+        processor = Processor(config, factory)
         if pr:
             await processor.process_checkout(path)
         elif update:
@@ -157,7 +155,7 @@ async def process(ctx: click.Context) -> None:
     config = ctx.obj["config"]
     async with aiohttp.ClientSession() as session:
         factory = Factory(config, session)
-        processor = factory.create_processor()
+        processor = Processor(config, factory)
         await processor.process()
 
 

--- a/src/neophile/factory.py
+++ b/src/neophile/factory.py
@@ -2,29 +2,24 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 
-from neophile.analysis.helm import HelmAnalyzer
-from neophile.analysis.kustomize import KustomizeAnalyzer
-from neophile.analysis.pre_commit import PreCommitAnalyzer
-from neophile.analysis.python import PythonAnalyzer
-from neophile.inventory.github import GitHubInventory
-from neophile.inventory.helm import CachedHelmInventory, HelmInventory
-from neophile.pr import PullRequester
-from neophile.processor import Processor
-from neophile.scanner.helm import HelmScanner
-from neophile.scanner.kustomize import KustomizeScanner
-from neophile.scanner.pre_commit import PreCommitScanner
-from neophile.virtualenv import VirtualEnv
+from aiohttp import ClientSession
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from aiohttp import ClientSession
-
-    from neophile.analysis.base import BaseAnalyzer
-    from neophile.config import Configuration
-    from neophile.scanner.base import BaseScanner
+from .analysis.base import BaseAnalyzer
+from .analysis.helm import HelmAnalyzer
+from .analysis.kustomize import KustomizeAnalyzer
+from .analysis.pre_commit import PreCommitAnalyzer
+from .analysis.python import PythonAnalyzer
+from .config import Configuration
+from .inventory.github import GitHubInventory
+from .inventory.helm import CachedHelmInventory, HelmInventory
+from .pr import PullRequester
+from .scanner.base import BaseScanner
+from .scanner.helm import HelmScanner
+from .scanner.kustomize import KustomizeScanner
+from .scanner.pre_commit import PreCommitScanner
+from .virtualenv import VirtualEnv
 
 __all__ = ["Factory"]
 
@@ -190,10 +185,6 @@ class Factory:
             return PythonAnalyzer(path, virtualenv)
         else:
             return PythonAnalyzer(path)
-
-    def create_processor(self) -> Processor:
-        """Create a new repository processor."""
-        return Processor(self._config, self)
 
     def create_pull_requester(self, path: Path) -> PullRequester:
         """Create a new pull requester.

--- a/src/neophile/inventory/github.py
+++ b/src/neophile/inventory/github.py
@@ -3,22 +3,13 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 
-from aiohttp import ClientError
+from aiohttp import ClientError, ClientSession
 from gidgethub import BadRequest
 from gidgethub.aiohttp import GitHubAPI
 
-from neophile.inventory.version import (
-    PackagingVersion,
-    ParsedVersion,
-    SemanticVersion,
-)
-
-if TYPE_CHECKING:
-    from aiohttp import ClientSession
-
-    from neophile.config import Configuration
+from ..config import Configuration
+from .version import PackagingVersion, ParsedVersion, SemanticVersion
 
 __all__ = [
     "GitHubInventory",

--- a/src/neophile/inventory/helm.py
+++ b/src/neophile/inventory/helm.py
@@ -4,18 +4,14 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import Any
 from urllib.parse import urljoin
 
+from aiohttp import ClientSession
 from ruamel.yaml import YAML
 
-from neophile.inventory.version import SemanticVersion
-
-if TYPE_CHECKING:
-    from pathlib import Path
-    from typing import Any
-
-    from aiohttp import ClientSession
+from .version import SemanticVersion
 
 __all__ = [
     "CachedHelmInventory",

--- a/src/neophile/pr.py
+++ b/src/neophile/pr.py
@@ -3,29 +3,22 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
-from urllib.parse import urlencode, urlparse
+from pathlib import Path
+from typing import ClassVar
+from urllib.parse import ParseResult, urlencode, urlparse
 
+from aiohttp import ClientSession
 from gidgethub import QueryError
 from gidgethub.aiohttp import GitHubAPI
 from git import PushInfo, Remote
 from git.repo import Repo
 from git.util import Actor
 
-from neophile.config import GitHubRepository
-from neophile.exceptions import PushError
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from pathlib import Path
-    from typing import ClassVar
-    from urllib.parse import ParseResult
-
-    from aiohttp import ClientSession
-
-    from neophile.config import Configuration
-    from neophile.update.base import Update
+from .config import Configuration, GitHubRepository
+from .exceptions import PushError
+from .update.base import Update
 
 __all__ = [
     "CommitMessage",

--- a/src/neophile/processor.py
+++ b/src/neophile/processor.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 
-from neophile.repository import Repository
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from neophile.config import Configuration
-    from neophile.factory import Factory
-    from neophile.update.base import Update
+from .config import Configuration
+from .factory import Factory
+from .repository import Repository
+from .update.base import Update
 
 __all__ = ["Processor"]
 

--- a/src/neophile/scanner/helm.py
+++ b/src/neophile/scanner/helm.py
@@ -7,10 +7,9 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
-from neophile.scanner.base import BaseScanner
-from neophile.scanner.util import find_files
-
 from ..models.dependencies import HelmDependency
+from .base import BaseScanner
+from .util import find_files
 
 __all__ = ["HelmScanner"]
 

--- a/src/neophile/scanner/kustomize.py
+++ b/src/neophile/scanner/kustomize.py
@@ -7,10 +7,9 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
-from neophile.scanner.base import BaseScanner
-from neophile.scanner.util import find_files
-
 from ..models.dependencies import KustomizeDependency
+from .base import BaseScanner
+from .util import find_files
 
 __all__ = ["KustomizeScanner"]
 

--- a/src/neophile/scanner/pre_commit.py
+++ b/src/neophile/scanner/pre_commit.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 from urllib.parse import urlparse
 
 from ruamel.yaml import YAML
 
-from neophile.scanner.base import BaseScanner
-
 from ..models.dependencies import PreCommitDependency
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from .base import BaseScanner
 
 __all__ = ["PreCommitScanner"]
 

--- a/src/neophile/update/helm.py
+++ b/src/neophile/update/helm.py
@@ -7,8 +7,8 @@ from pathlib import Path  # noqa: F401
 
 from ruamel.yaml import YAML
 
-from neophile.exceptions import DependencyNotFoundError
-from neophile.update.base import Update
+from ..exceptions import DependencyNotFoundError
+from .base import Update
 
 __all__ = ["HelmUpdate"]
 

--- a/src/neophile/update/kustomize.py
+++ b/src/neophile/update/kustomize.py
@@ -8,8 +8,8 @@ from pathlib import Path  # noqa: F401
 
 from ruamel.yaml import YAML
 
-from neophile.exceptions import DependencyNotFoundError
-from neophile.update.base import Update
+from ..exceptions import DependencyNotFoundError
+from .base import Update
 
 __all__ = ["KustomizeUpdate"]
 

--- a/src/neophile/update/pre_commit.py
+++ b/src/neophile/update/pre_commit.py
@@ -8,8 +8,8 @@ from urllib.parse import urlparse
 
 from ruamel.yaml import YAML
 
-from neophile.exceptions import DependencyNotFoundError
-from neophile.update.base import Update
+from ..exceptions import DependencyNotFoundError
+from .base import Update
 
 __all__ = ["PreCommitUpdate"]
 

--- a/src/neophile/update/python.py
+++ b/src/neophile/update/python.py
@@ -6,12 +6,9 @@ import logging
 import subprocess
 from dataclasses import InitVar, dataclass
 from pathlib import Path  # noqa: F401
-from typing import TYPE_CHECKING
 
-from neophile.update.base import Update
-
-if TYPE_CHECKING:
-    from neophile.virtualenv import VirtualEnv
+from ..virtualenv import VirtualEnv
+from .base import Update
 
 __all__ = ["PythonFrozenUpdate"]
 

--- a/src/neophile/virtualenv.py
+++ b/src/neophile/virtualenv.py
@@ -4,14 +4,11 @@ from __future__ import annotations
 
 import os
 import subprocess
-from typing import TYPE_CHECKING
+from collections.abc import Sequence
+from pathlib import Path
+from subprocess import CompletedProcess
+from typing import Any
 from venv import EnvBuilder
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from pathlib import Path
-    from subprocess import CompletedProcess
-    from typing import Any
 
 __all__ = ["VirtualEnv"]
 

--- a/tests/analysis/helm_test.py
+++ b/tests/analysis/helm_test.py
@@ -3,19 +3,17 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
+from aiohttp import ClientSession
 from aioresponses import aioresponses
 
 from neophile.analysis.helm import HelmAnalyzer
 from neophile.inventory.helm import HelmInventory
 from neophile.scanner.helm import HelmScanner
 from neophile.update.helm import HelmUpdate
-from tests.util import dict_to_yaml
 
-if TYPE_CHECKING:
-    from aiohttp import ClientSession
+from ..util import dict_to_yaml
 
 MOCK_REPOSITORIES = {
     "https://kubernetes-charts.storage.googleapis.com/index.yaml": {

--- a/tests/analysis/kustomize_test.py
+++ b/tests/analysis/kustomize_test.py
@@ -3,18 +3,16 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
+from aiohttp import ClientSession
 from aioresponses import aioresponses
 
 from neophile.config import Configuration
 from neophile.factory import Factory
 from neophile.update.kustomize import KustomizeUpdate
-from tests.util import register_mock_github_tags
 
-if TYPE_CHECKING:
-    from aiohttp import ClientSession
+from ..util import register_mock_github_tags
 
 
 @pytest.mark.asyncio

--- a/tests/analysis/pre_commit_test.py
+++ b/tests/analysis/pre_commit_test.py
@@ -3,18 +3,16 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
+from aiohttp import ClientSession
 from aioresponses import aioresponses
 
 from neophile.config import Configuration
 from neophile.factory import Factory
 from neophile.update.pre_commit import PreCommitUpdate
-from tests.util import register_mock_github_tags
 
-if TYPE_CHECKING:
-    from aiohttp import ClientSession
+from ..util import register_mock_github_tags
 
 
 @pytest.mark.asyncio

--- a/tests/analysis/python_test.py
+++ b/tests/analysis/python_test.py
@@ -4,20 +4,18 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
+from _pytest.logging import LogCaptureFixture
+from aiohttp import ClientSession
 from git.util import Actor
 
 from neophile.config import Configuration
 from neophile.exceptions import UncommittedChangesError
 from neophile.factory import Factory
 from neophile.update.python import PythonFrozenUpdate
-from tests.util import setup_python_repo
 
-if TYPE_CHECKING:
-    from _pytest.logging import LogCaptureFixture
-    from aiohttp import ClientSession
+from ..util import setup_python_repo
 
 
 @pytest.mark.asyncio

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -7,8 +7,8 @@ import re
 import shutil
 from io import StringIO
 from pathlib import Path
-from typing import TYPE_CHECKING
-from unittest.mock import call
+from typing import Any
+from unittest.mock import Mock, call
 
 from aioresponses import CallbackResult, aioresponses
 from click.testing import CliRunner
@@ -19,11 +19,8 @@ from ruamel.yaml import YAML
 
 from neophile.cli import main
 from neophile.pr import CommitMessage
-from tests.util import dict_to_yaml, mock_enable_auto_merge
 
-if TYPE_CHECKING:
-    from typing import Any
-    from unittest.mock import Mock
+from .util import dict_to_yaml, mock_enable_auto_merge
 
 
 def test_help() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import AsyncIterator, Iterator
 from unittest.mock import Mock, patch
 
 import pytest
 import pytest_asyncio
 from aiohttp import ClientSession
 from git import PushInfo, Remote
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterator
 
 
 @pytest.fixture

--- a/tests/inventory/github_test.py
+++ b/tests/inventory/github_test.py
@@ -2,17 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
+from aiohttp import ClientSession
 from aioresponses import aioresponses
 
 from neophile.config import Configuration
 from neophile.inventory.github import GitHubInventory
-from tests.util import register_mock_github_tags
 
-if TYPE_CHECKING:
-    from aiohttp import ClientSession
+from ..util import register_mock_github_tags
 
 
 @pytest.mark.asyncio

--- a/tests/inventory/helm_test.py
+++ b/tests/inventory/helm_test.py
@@ -4,18 +4,16 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest.mock import ANY
 
 import pytest
+from aiohttp import ClientSession
 from aioresponses import aioresponses
 from ruamel.yaml import YAML
 
 from neophile.inventory.helm import CachedHelmInventory, HelmInventory
-from tests.util import dict_to_yaml
 
-if TYPE_CHECKING:
-    from aiohttp import ClientSession
+from ..util import dict_to_yaml
 
 EXPECTED = {
     "cadc-tap": "0.1.9",

--- a/tests/pr_test.py
+++ b/tests/pr_test.py
@@ -6,10 +6,11 @@ import json
 import re
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any
 from unittest.mock import Mock, call, patch
 
 import pytest
+from aiohttp import ClientSession
 from aioresponses import CallbackResult, aioresponses
 from git import PushInfo, Remote
 from git.repo import Repo
@@ -21,12 +22,8 @@ from neophile.exceptions import PushError
 from neophile.pr import CommitMessage, PullRequester
 from neophile.repository import Repository
 from neophile.update.helm import HelmUpdate
-from tests.util import mock_enable_auto_merge
 
-if TYPE_CHECKING:
-    from typing import Any
-
-    from aiohttp import ClientSession
+from .util import mock_enable_auto_merge
 
 
 def setup_repo(tmp_path: Path) -> Repo:

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 from git.repo import Repo
 from git.util import Actor
 
 from neophile.repository import Repository
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def create_repo(upstream_path: Path, checkout_path: Path) -> Repo:

--- a/tests/update/python_test.py
+++ b/tests/update/python_test.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import re
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING
+
+from _pytest.logging import LogCaptureFixture
 
 from neophile.update.python import PythonFrozenUpdate
 from neophile.virtualenv import VirtualEnv
-from tests.util import setup_python_repo
 
-if TYPE_CHECKING:
-    from _pytest.logging import LogCaptureFixture
+from ..util import setup_python_repo
 
 
 def test_python_update(tmp_path: Path) -> None:

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,23 +4,18 @@ from __future__ import annotations
 
 import json
 import shutil
+from collections.abc import Mapping, Sequence
 from io import StringIO
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any
 
-from aioresponses import CallbackResult
+from aioresponses import CallbackResult, aioresponses
 from gidgethub import QueryError
 from git.repo import Repo
 from git.util import Actor
 from ruamel.yaml import YAML
 
 from neophile.pr import _GRAPHQL_ENABLE_AUTO_MERGE, _GRAPHQL_PR_ID
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
-    from typing import Any
-
-    from aioresponses import aioresponses
 
 
 def dict_to_yaml(data: Mapping[str, Any]) -> str:

--- a/tests/virtualenv_test.py
+++ b/tests/virtualenv_test.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 from neophile.virtualenv import VirtualEnv
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def test_provided_env(tmp_path: Path) -> None:


### PR DESCRIPTION
Match our other packages by adopting relative imports and dropping use of TYPE_CHECKING. The latter is too fiddly and doesn't seem worth the effort.

This introduced a circular dependency between Factory and Processor. Resolve that by removing the ability for a Factory to create a Processor and instead create a Processor directly. (This will be revisited in the future.)

Fix the directory into which the internal API documentation was being generated.