### PR TITLE
DM-39519: Switch to Self types

### DIFF
--- a/src/neophile/cli.py
+++ b/src/neophile/cli.py
@@ -12,7 +12,7 @@ from ruamel.yaml import YAML
 from safir.asyncio import run_with_asyncio
 from xdg import XDG_CONFIG_HOME
 
-from .config import Configuration
+from .config import Config
 from .factory import Factory
 from .inventory.github import GitHubInventory
 from .processor import Processor
@@ -43,9 +43,9 @@ def main(ctx: click.Context, config_path: Path) -> None:
     """Command-line interface for neophile."""
     ctx.ensure_object(dict)
     if config_path.exists():
-        ctx.obj["config"] = Configuration.from_file(config_path)
+        ctx.obj["config"] = Config.from_file(config_path)
     else:
-        ctx.obj["config"] = Configuration()
+        ctx.obj["config"] = Config()
 
 
 @main.command()

--- a/src/neophile/config.py
+++ b/src/neophile/config.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Self
 
 from pydantic import BaseModel, BaseSettings, Field, SecretStr
 from ruamel.yaml import YAML
 from xdg import XDG_CACHE_HOME
 
 __all__ = [
-    "Configuration",
+    "Config",
     "GitHubRepository",
 ]
 
@@ -24,7 +25,7 @@ class GitHubRepository(BaseModel):
     """The name of the repository."""
 
 
-class Configuration(BaseSettings):
+class Config(BaseSettings):
     """Configuration for neophile."""
 
     allow_expressions: bool = Field(
@@ -65,20 +66,20 @@ class Configuration(BaseSettings):
         env_prefix = "neophile_"
 
     @classmethod
-    def from_file(cls, path: Path) -> Configuration:
+    def from_file(cls, path: Path) -> Self:
         """Initialize the configuration from a file.
 
         Parameters
         ----------
-        path : `str`
+        path
             Path to a configuration file in YAML format.
 
         Returns
         -------
-        config : `Configuration`
+        Config
             The configuration.
         """
         yaml = YAML()
         with path.open("r") as f:
             settings = yaml.load(f)
-        return Configuration.parse_obj(settings)
+        return cls.parse_obj(settings)

--- a/src/neophile/factory.py
+++ b/src/neophile/factory.py
@@ -11,7 +11,7 @@ from .analysis.helm import HelmAnalyzer
 from .analysis.kustomize import KustomizeAnalyzer
 from .analysis.pre_commit import PreCommitAnalyzer
 from .analysis.python import PythonAnalyzer
-from .config import Configuration
+from .config import Config
 from .inventory.github import GitHubInventory
 from .inventory.helm import CachedHelmInventory, HelmInventory
 from .pr import PullRequester
@@ -29,13 +29,13 @@ class Factory:
 
     Parameters
     ----------
-    config : `neophile.config.Configuration`
+    config
         neophile configuration.
-    session : `aiohttp.ClientSession`
+    session
         The client session to use for requests.
     """
 
-    def __init__(self, config: Configuration, session: ClientSession) -> None:
+    def __init__(self, config: Config, session: ClientSession) -> None:
         self._config = config
         self._session = session
 

--- a/src/neophile/inventory/github.py
+++ b/src/neophile/inventory/github.py
@@ -8,7 +8,7 @@ from aiohttp import ClientError, ClientSession
 from gidgethub import BadRequest
 from gidgethub.aiohttp import GitHubAPI
 
-from ..config import Configuration
+from ..config import Config
 from .version import PackagingVersion, ParsedVersion, SemanticVersion
 
 __all__ = [
@@ -21,13 +21,13 @@ class GitHubInventory:
 
     Parameters
     ----------
-    config : `neophile.config.Configuration`
+    config
         neophile configuration.
-    session : `aiohttp.ClientSession`
+    session
         The aiohttp client session to use to make requests for GitHub tags.
     """
 
-    def __init__(self, config: Configuration, session: ClientSession) -> None:
+    def __init__(self, config: Config, session: ClientSession) -> None:
         self._github = GitHubAPI(
             session,
             config.github_user,

--- a/src/neophile/inventory/version.py
+++ b/src/neophile/inventory/version.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
+from typing import Self
 
 from packaging import version
 from semver.version import Version
@@ -34,7 +35,7 @@ class ParsedVersion(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def from_str(cls, string: str) -> ParsedVersion:
+    def from_str(cls, string: str) -> Self:
         """Parse a string into a version.
 
         Parameters
@@ -87,7 +88,7 @@ class PackagingVersion(ParsedVersion):
     """The raw version string."""
 
     @classmethod
-    def from_str(cls, string: str) -> PackagingVersion:
+    def from_str(cls, string: str) -> Self:
         """Parse a string into a `~packaging.version.Version`.
 
         Parameters
@@ -147,7 +148,7 @@ class SemanticVersion(ParsedVersion):
     """The raw version string, which may start with a v."""
 
     @classmethod
-    def from_str(cls, string: str) -> SemanticVersion:
+    def from_str(cls, string: str) -> Self:
         """Parse a string into a `SemanticVersion`.
 
         Parameters

--- a/src/neophile/pr.py
+++ b/src/neophile/pr.py
@@ -16,7 +16,7 @@ from git import PushInfo, Remote
 from git.repo import Repo
 from git.util import Actor
 
-from .config import Configuration, GitHubRepository
+from .config import Config, GitHubRepository
 from .exceptions import PushError
 from .update.base import Update
 
@@ -70,16 +70,16 @@ class PullRequester:
 
     Parameters
     ----------
-    path : `pathlib.Path`
+    path
         Path to the Git repository.
-    config : `neophile.config.Configuration`
+    config
         neophile configuration.
-    session : `aiohttp.ClientSession`
+    session
         The client session to use for requests.
     """
 
     def __init__(
-        self, path: Path, config: Configuration, session: ClientSession
+        self, path: Path, config: Config, session: ClientSession
     ) -> None:
         self._config = config
         self._github = GitHubAPI(

--- a/src/neophile/processor.py
+++ b/src/neophile/processor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .config import Configuration
+from .config import Config
 from .factory import Factory
 from .repository import Repository
 from .update.base import Update
@@ -17,13 +17,13 @@ class Processor:
 
     Parameters
     ----------
-    config : `neophile.config.Configuration`
+    config
         The neophile configuration.
-    factory : `neophile.factory.Factory`
+    factory
         Used to create additional components where necessary.
     """
 
-    def __init__(self, config: Configuration, factory: Factory) -> None:
+    def __init__(self, config: Config, factory: Factory) -> None:
         self._config = config
         self._factory = factory
 

--- a/src/neophile/repository.py
+++ b/src/neophile/repository.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import Self
 
 from git.repo import Repo
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 __all__ = ["Repository"]
 
@@ -22,7 +20,7 @@ class Repository:
     """
 
     @classmethod
-    def clone_or_update(cls, path: Path, url: str) -> Repository:
+    def clone_or_update(cls, path: Path, url: str) -> Self:
         """Clone a repository or update an existing repository.
 
         Parameters

--- a/tests/analysis/kustomize_test.py
+++ b/tests/analysis/kustomize_test.py
@@ -8,7 +8,7 @@ import pytest
 from aiohttp import ClientSession
 from aioresponses import aioresponses
 
-from neophile.config import Configuration
+from neophile.config import Config
 from neophile.factory import Factory
 from neophile.update.kustomize import KustomizeUpdate
 
@@ -26,7 +26,7 @@ async def test_analyzer(session: ClientSession) -> None:
         register_mock_github_tags(
             mock, "lsst-sqre", "sqrbot", ["20170114", "0.6.1", "0.7.0"]
         )
-        factory = Factory(Configuration(), session)
+        factory = Factory(Config(), session)
         analyzer = factory.create_kustomize_analyzer(data_path)
         results = await analyzer.analyze()
 
@@ -49,6 +49,6 @@ async def test_analyzer_missing(session: ClientSession) -> None:
     data_path = Path(__file__).parent.parent / "data" / "kubernetes"
 
     with aioresponses():
-        factory = Factory(Configuration(), session)
+        factory = Factory(Config(), session)
         analyzer = factory.create_kustomize_analyzer(data_path)
         assert await analyzer.analyze() == []

--- a/tests/analysis/pre_commit_test.py
+++ b/tests/analysis/pre_commit_test.py
@@ -8,7 +8,7 @@ import pytest
 from aiohttp import ClientSession
 from aioresponses import aioresponses
 
-from neophile.config import Configuration
+from neophile.config import Config
 from neophile.factory import Factory
 from neophile.update.pre_commit import PreCommitUpdate
 
@@ -31,7 +31,7 @@ async def test_analyzer(session: ClientSession) -> None:
         )
         register_mock_github_tags(mock, "ambv", "black", ["20.0.0", "19.10b0"])
         register_mock_github_tags(mock, "pycqa", "flake8", ["3.7.0", "3.9.0"])
-        factory = Factory(Configuration(), session)
+        factory = Factory(Config(), session)
         analyzer = factory.create_pre_commit_analyzer(data_path)
         results = await analyzer.analyze()
 

--- a/tests/analysis/python_test.py
+++ b/tests/analysis/python_test.py
@@ -10,7 +10,7 @@ from _pytest.logging import LogCaptureFixture
 from aiohttp import ClientSession
 from git.util import Actor
 
-from neophile.config import Configuration
+from neophile.config import Config
 from neophile.exceptions import UncommittedChangesError
 from neophile.factory import Factory
 from neophile.update.python import PythonFrozenUpdate
@@ -23,7 +23,7 @@ async def test_analyzer(tmp_path: Path, session: ClientSession) -> None:
     repo = setup_python_repo(tmp_path)
     actor = Actor("Someone", "someone@example.com")
 
-    factory = Factory(Configuration(), session)
+    factory = Factory(Config(), session)
     analyzer = factory.create_python_analyzer(tmp_path)
     results = await analyzer.analyze()
 
@@ -37,7 +37,7 @@ async def test_analyzer(tmp_path: Path, session: ClientSession) -> None:
     # If the repo is dirty, analysis will fail.
     subprocess.run(["make", "update-deps"], cwd=str(tmp_path), check=True)
     assert repo.is_dirty()
-    factory = Factory(Configuration(), session)
+    factory = Factory(Config(), session)
     analyzer = factory.create_python_analyzer(tmp_path)
     with pytest.raises(UncommittedChangesError):
         results = await analyzer.analyze()
@@ -46,7 +46,7 @@ async def test_analyzer(tmp_path: Path, session: ClientSession) -> None:
     # file.  Analysis should now return no changes.
     repo.index.add(str(tmp_path / "requirements"))
     repo.index.commit("Update dependencies", author=actor, committer=actor)
-    factory = Factory(Configuration(), session)
+    factory = Factory(Config(), session)
     analyzer = factory.create_python_analyzer(tmp_path)
     results = await analyzer.analyze()
     assert results == []
@@ -56,7 +56,7 @@ async def test_analyzer(tmp_path: Path, session: ClientSession) -> None:
 async def test_analyzer_update(tmp_path: Path, session: ClientSession) -> None:
     repo = setup_python_repo(tmp_path)
 
-    factory = Factory(Configuration(), session)
+    factory = Factory(Config(), session)
     analyzer = factory.create_python_analyzer(tmp_path)
     results = await analyzer.update()
 
@@ -72,7 +72,7 @@ async def test_virtualenv(
 ) -> None:
     setup_python_repo(tmp_path, require_venv=True)
 
-    factory = Factory(Configuration(), session)
+    factory = Factory(Config(), session)
     analyzer = factory.create_python_analyzer(tmp_path)
     assert await analyzer.analyze() == []
     assert "make update-deps failed" in caplog.records[0].msg

--- a/tests/inventory/github_test.py
+++ b/tests/inventory/github_test.py
@@ -6,7 +6,7 @@ import pytest
 from aiohttp import ClientSession
 from aioresponses import aioresponses
 
-from neophile.config import Configuration
+from neophile.config import Config
 from neophile.inventory.github import GitHubInventory
 
 from ..util import register_mock_github_tags
@@ -24,7 +24,7 @@ async def test_inventory(session: ClientSession) -> None:
     for test in tests:
         with aioresponses() as mock:
             register_mock_github_tags(mock, "foo", "bar", test["tags"])
-            inventory = GitHubInventory(Configuration(), session)
+            inventory = GitHubInventory(Config(), session)
             latest = await inventory.inventory("foo", "bar")
         assert latest == test["latest"]
 
@@ -35,7 +35,7 @@ async def test_inventory_semantic(session: ClientSession) -> None:
 
     with aioresponses() as mock:
         register_mock_github_tags(mock, "foo", "bar", tags)
-        inventory = GitHubInventory(Configuration(), session)
+        inventory = GitHubInventory(Config(), session)
         latest = await inventory.inventory("foo", "bar")
         assert latest == "20171120-1"
         latest = await inventory.inventory("foo", "bar", semantic=True)
@@ -47,6 +47,6 @@ async def test_inventory_missing(session: ClientSession) -> None:
     """Missing and empty version lists should return None."""
     with aioresponses() as mock:
         register_mock_github_tags(mock, "foo", "bar", [])
-        inventory = GitHubInventory(Configuration(), session)
+        inventory = GitHubInventory(Config(), session)
         assert await inventory.inventory("foo", "bar") is None
         assert await inventory.inventory("foo", "nonexistent") is None

--- a/tests/pr_test.py
+++ b/tests/pr_test.py
@@ -17,7 +17,7 @@ from git.repo import Repo
 from git.util import Actor
 from pydantic import SecretStr
 
-from neophile.config import Configuration, GitHubRepository
+from neophile.config import Config, GitHubRepository
 from neophile.exceptions import PushError
 from neophile.pr import CommitMessage, PullRequester
 from neophile.repository import Repository
@@ -45,7 +45,7 @@ async def test_pr(
     tmp_path: Path, session: ClientSession, mock_push: Mock
 ) -> None:
     repo = setup_repo(tmp_path)
-    config = Configuration(
+    config = Config(
         github_user="someone", github_token=SecretStr("some-token")
     )
     update = HelmUpdate(
@@ -97,7 +97,7 @@ async def test_pr(
 @pytest.mark.asyncio
 async def test_pr_push_failure(tmp_path: Path, session: ClientSession) -> None:
     setup_repo(tmp_path)
-    config = Configuration(
+    config = Config(
         github_user="someone", github_token=SecretStr("some-token")
     )
     update = HelmUpdate(
@@ -137,7 +137,7 @@ async def test_pr_no_automerge(
     tmp_path: Path, session: ClientSession, mock_push: Mock
 ) -> None:
     repo = setup_repo(tmp_path)
-    config = Configuration(
+    config = Config(
         github_user="someone", github_token=SecretStr("some-token")
     )
     update = HelmUpdate(
@@ -192,7 +192,7 @@ async def test_pr_update(
 ) -> None:
     """Test updating an existing PR."""
     repo = setup_repo(tmp_path)
-    config = Configuration(
+    config = Config(
         github_email="otheremail@example.com",
         github_token=SecretStr("some-token"),
         github_user="someone",
@@ -255,9 +255,7 @@ async def test_get_authenticated_remote(
 ) -> None:
     repo = Repo.init(str(tmp_path), initial_branch="main")
 
-    config = Configuration(
-        github_user="test", github_token=SecretStr("some-token")
-    )
+    config = Config(github_user="test", github_token=SecretStr("some-token"))
     pr = PullRequester(tmp_path, config, session)
 
     remote = Remote.create(repo, "origin", "https://github.com/foo/bar")
@@ -281,9 +279,7 @@ async def test_get_authenticated_remote(
 async def test_get_github_repo(tmp_path: Path, session: ClientSession) -> None:
     repo = Repo.init(str(tmp_path), initial_branch="main")
 
-    config = Configuration(
-        github_user="test", github_token=SecretStr("some-token")
-    )
+    config = Config(github_user="test", github_token=SecretStr("some-token"))
     pr = PullRequester(tmp_path, config, session)
 
     remote = Remote.create(repo, "origin", "git@github.com:foo/bar.git")

--- a/tests/processor_test.py
+++ b/tests/processor_test.py
@@ -19,7 +19,7 @@ from git.repo import Repo
 from git.util import Actor
 from ruamel.yaml import YAML
 
-from neophile.config import Configuration, GitHubRepository
+from neophile.config import Config, GitHubRepository
 from neophile.factory import Factory
 from neophile.pr import CommitMessage
 from neophile.processor import Processor
@@ -84,7 +84,7 @@ async def test_processor(tmp_path: Path, session: ClientSession) -> None:
     tmp_repo = setup_python_repo(tmp_path / "tmp", require_venv=True)
     upstream_path = tmp_path / "upstream"
     create_upstream_git_repository(tmp_repo, upstream_path)
-    config = Configuration(
+    config = Config(
         repositories=[GitHubRepository(owner="foo", repo="bar")],
         work_area=tmp_path / "work",
     )
@@ -168,7 +168,7 @@ async def test_no_updates(tmp_path: Path, session: ClientSession) -> None:
     tmp_repo.index.commit("Initial commit", author=actor, committer=actor)
     upstream_path = tmp_path / "upstream"
     create_upstream_git_repository(tmp_repo, upstream_path)
-    config = Configuration(
+    config = Config(
         repositories=[GitHubRepository(owner="foo", repo="bar")],
         work_area=tmp_path / "work",
     )
@@ -196,7 +196,7 @@ async def test_allow_expressions(
     tmp_repo = setup_kubernetes_repo(tmp_path / "tmp")
     upstream_path = tmp_path / "upstream"
     create_upstream_git_repository(tmp_repo, upstream_path)
-    config = Configuration(
+    config = Config(
         allow_expressions=True,
         cache_enabled=False,
         repositories=[GitHubRepository(owner="foo", repo="bar")],


### PR DESCRIPTION
Use Self types for class constructor methods. Take advantage of this to rename Configuration back to Config, matching other packages, now that it no longer conflicts with the Pydantic class.