### PR TITLE
DM-39519: Convert to new docstring format

### DIFF
--- a/src/neophile/analysis/base.py
+++ b/src/neophile/analysis/base.py
@@ -18,17 +18,17 @@ class BaseAnalyzer(ABC):
 
         Parameters
         ----------
-        update : `bool`, optional
+        update
             If set to `True`, leave the update applied if this is more
-            efficient.  Used by analyzers like the Python frozen dependency
+            efficient. Used by analyzers like the Python frozen dependency
             analyzer that have to do work and apply the update to see if any
-            update is necessary.  They can then mark the returned update as
+            update is necessary. They can then mark the returned update as
             already applied and not have to run it twice.
 
         Returns
         -------
-        results : List[`neophile.update.base.Update`]
-            A list of updates.
+        list of Update
+            List of updates found.
         """
 
     @property
@@ -41,12 +41,12 @@ class BaseAnalyzer(ABC):
         """
 
     async def update(self) -> list[Update]:
-        """Analyze a tree, apply updates, and return them as a list.
+        """Analyze a tree and apply updates.
 
         Returns
         -------
-        results : List[`neophile.update.base.Update`]
-            A list of updates.
+        list of Update
+            List of updates applied.
         """
         updates = await self.analyze(update=True)
         for update in updates:

--- a/src/neophile/analysis/helm.py
+++ b/src/neophile/analysis/helm.py
@@ -19,14 +19,14 @@ class HelmAnalyzer(BaseAnalyzer):
 
     Parameters
     ----------
-    scanner : `neophile.scanner.helm.HelmScanner`
+    scanner
         Scanner for Helm dependencies.
-    inventory : `neophile.inventory.helm.HelmInventory`
+    inventory
         Inventory for Helm repositories.
-    allow_expressions : `bool`, optional
+    allow_expressions
         If set, allow dependencies to be expressed as expressions, and only
         report a needed update if the latest version is outside the range of
-        the expression.  Defaults to false.
+        the expression.
     """
 
     def __init__(
@@ -45,13 +45,13 @@ class HelmAnalyzer(BaseAnalyzer):
 
         Parameters
         ----------
-        update : `bool`, optional
+        update
             Ignored for this analyzer.
 
         Returns
         -------
-        results : List[`neophile.update.base.Update`]
-            A list of updates.
+        list of Update
+            List of needed updates.
         """
         dependencies = self._scanner.scan()
         repositories = {d.repository for d in dependencies}
@@ -89,16 +89,16 @@ class HelmAnalyzer(BaseAnalyzer):
 
         Parameters
         ----------
-        current : `str`
-            The current version number.  If this is not a valid version number,
-            it is assumed to be a match pattern.
-        latest_str : `str`
-            The version number of the latest release.
+        current
+            Current version number. If this is not a valid version number, it
+            is assumed to be a match pattern.
+        latest_str
+            Version number of the latest release.
 
         Returns
         -------
-        result : `bool`
-            Whether this dependency should be updated.  Returns true if the
+        bool
+            Whether this dependency should be updated. Returns `True` if the
             current version is invalid or if it is older than the latest
             version.
         """

--- a/src/neophile/analysis/kustomize.py
+++ b/src/neophile/analysis/kustomize.py
@@ -16,9 +16,9 @@ class KustomizeAnalyzer(BaseAnalyzer):
 
     Parameters
     ----------
-    scanner : `neophile.scanner.kustomize.KustomizeScanner`
+    scanner
         Scanner for Kustomize dependencies.
-    inventory : `neophile.inventory.github.GitHubInventory`
+    inventory
         Inventory for GitHub tags.
     """
 
@@ -33,13 +33,13 @@ class KustomizeAnalyzer(BaseAnalyzer):
 
         Parameters
         ----------
-        update : `bool`, optional
+        update
             Ignored for this analyzer.
 
         Returns
         -------
-        results : List[`neophile.update.base.Update`]
-            A list of updates.
+        list of Update
+            List of needed updates.
         """
         dependencies = self._scanner.scan()
 

--- a/src/neophile/analysis/pre_commit.py
+++ b/src/neophile/analysis/pre_commit.py
@@ -16,9 +16,9 @@ class PreCommitAnalyzer(BaseAnalyzer):
 
     Parameters
     ----------
-    scanner : `neophile.scanner.pre_commit.PreCommitScanner`
+    scanner
         Scanner for pre-commit hook dependencies.
-    inventory : `neophile.inventory.github.GitHubInventory`
+    inventory
         Inventory for GitHub tags.
     """
 
@@ -29,17 +29,17 @@ class PreCommitAnalyzer(BaseAnalyzer):
         self._inventory = inventory
 
     async def analyze(self, *, update: bool = False) -> list[Update]:
-        """Analyze a tree and return a list of needed pre-commit hook changes.
+        """Analyze a tree and return needed pre-commit hook changes.
 
         Parameters
         ----------
-        update : `bool`, optional
+        update
             Ignored for this analyzer.
 
         Returns
         -------
-        results : List[`neophile.update.base.Update`]
-            A list of updates.
+        list of Update
+            List of needed updates.
         """
         dependencies = self._scanner.scan()
 

--- a/src/neophile/analysis/python.py
+++ b/src/neophile/analysis/python.py
@@ -22,9 +22,9 @@ class PythonAnalyzer(BaseAnalyzer):
 
     Parameters
     ----------
-    root : `pathlib.Path`
+    root
         Root of the directory tree to analyze.
-    virtualenv : `neophile.virtualenv.VirtualEnv`, optional
+    virtualenv
         Virtual environment manager.
     """
 
@@ -39,24 +39,24 @@ class PythonAnalyzer(BaseAnalyzer):
 
         Parameters
         ----------
-        update : `bool`, optional
-            If set to `True`, leave the update applied.  This avoids having
-            to run ``make update-deps`` twice, once to see if an update is
-            needed and again to apply it properly.
+        update
+            If set to `True`, leave the update applied. This avoids having to
+            run ``make update-deps`` twice, once to see if an update is needed
+            and again to apply it properly.
 
         Returns
         -------
-        results : List[`neophile.update.base.Update`]
-            Will contain either no elements (no updates needed) or a single
+        list of Update
+            Either an empty list (no updates needed) or a list with a single
             element (an update needed).
 
         Raises
         ------
-        neophile.exceptions.UncommittedChangesError
-            The repository being analyzed has uncommitted changes and
-            therefore cannot be checked for updates.
+        UncommittedChangesError
+            Raised if the repository being analyzed has uncommitted changes
+            and therefore cannot be checked for updates.
         subprocess.CalledProcessError
-            Running ``make update-deps`` failed.
+            Raised if running ``make update-deps`` failed.
         """
         for name in ("Makefile", "requirements/main.in"):
             if not (self._root / name).exists():

--- a/src/neophile/cli.py
+++ b/src/neophile/cli.py
@@ -35,7 +35,7 @@ def print_yaml(results: Any) -> None:
     metavar="PATH",
     default=str(XDG_CONFIG_HOME / "neophile.yaml"),
     envvar="NEOPHILE_CONFIG",
-    help="Path to configuration",
+    help="Path to configuration.",
 )
 @click.version_option(message="%(version)s")
 @click.pass_context
@@ -71,21 +71,21 @@ def help(ctx: click.Context, topic: str | None) -> None:
 @click.option(
     "--allow-expressions/--no-allow-expressions",
     default=False,
-    help="Allow version match expressions",
+    help="Allow version match expressions.",
 )
 @click.option(
     "--path",
     type=click.Path(path_type=Path),
     default=Path.cwd(),
-    help="Path to analyze",
+    help="Path to analyze (default: current directory).",
 )
 @click.option(
-    "--pr/--no-pr", default=False, help="Generate a pull request of changes"
+    "--pr/--no-pr", default=False, help="Generate a pull request of changes."
 )
 @click.option(
     "--update/--no-update",
     default=False,
-    help="Update out-of-date dependencies",
+    help="Update out-of-date dependencies.",
 )
 @click.pass_context
 @run_with_asyncio
@@ -97,7 +97,7 @@ async def analyze(
     pr: bool,
     update: bool,
 ) -> None:
-    """Analyze the current directory for pending upgrades."""
+    """Analyze a path for pending upgrades."""
     config = ctx.obj["config"]
     config.allow_expressions = allow_expressions
 
@@ -164,7 +164,7 @@ async def process(ctx: click.Context) -> None:
     "--path",
     type=click.Path(path_type=Path),
     default=Path.cwd(),
-    help="Path to scan",
+    help="Path to scan (default: current directory).",
 )
 @click.pass_context
 @run_with_asyncio

--- a/src/neophile/factory.py
+++ b/src/neophile/factory.py
@@ -46,15 +46,14 @@ class Factory:
 
         Parameters
         ----------
-        path : `pathlib.Path`
+        path
             Path to the Git repository.
-        use_venv : `bool`, optional
-            Whether to use a virtualenv to isolate analysis.  Default is
-            false.
+        use_venv
+            Whether to use a virtualenv to isolate analysis.
 
         Returns
         -------
-        analyzers : List[`neophile.analysis.base.BaseAnalyzer`]
+        list of BaseAnalyzer
             List of all available analyzers.
 
         Notes
@@ -76,12 +75,12 @@ class Factory:
 
         Parameters
         ----------
-        path : `pathlib.Path`
+        path
             Path to the Git repository to scan.
 
         Returns
         -------
-        scanners : List[`neophile.scanner.base.BaseScanner`]
+        list of BaseScanner
             List of all available scanners.
         """
         return [
@@ -95,12 +94,12 @@ class Factory:
 
         Parameters
         ----------
-        path : `pathlib.Path`
+        path
             Path to the Git repository.
 
         Returns
         -------
-        analyzer : `neophile.analysis.helm.HelmAnalyzer`
+        HelmAnalyzer
             New analyzer.
         """
         scanner = HelmScanner(path)
@@ -119,7 +118,7 @@ class Factory:
 
         Returns
         -------
-        inventory : `neophile.inventory.helm.HelmInventory`
+        HelmInventory
             New inventory.
         """
         if not self._config.cache_enabled:
@@ -133,12 +132,12 @@ class Factory:
 
         Parameters
         ----------
-        path : `pathlib.Path`
+        path
             Path to the Git repository.
 
         Returns
         -------
-        analyzer : `neophile.analysis.kustomize.KustomizeAnalyzer`
+        KustomizeAnalyzer
             New analyzer.
         """
         scanner = KustomizeScanner(path)
@@ -150,12 +149,12 @@ class Factory:
 
         Parameters
         ----------
-        path : `pathlib.Path`
+        path
             Path to the Git repository.
 
         Returns
         -------
-        analyzer : `neophile.analysis.pre_commit.PreCommitAnalyzer`
+        PreCommitAnalyzer
             New analyzer.
         """
         scanner = PreCommitScanner(path)
@@ -169,15 +168,14 @@ class Factory:
 
         Parameters
         ----------
-        path : `pathlib.Path`
+        path
             Path to the Git repository.
-        use_venv : `bool`, optional
-            Whether to use a virtualenv to isolate analysis.  Default is
-            false.
+        use_venv
+            Whether to use a virtualenv to isolate analysis.
 
         Returns
         -------
-        analyzer : `neophile.analysis.python.PythonAnalyzer`
+        PythonAnalyzer
             New analyzer.
         """
         if use_venv:
@@ -191,12 +189,12 @@ class Factory:
 
         Parameters
         ----------
-        path : `pathlib.Path`
+        path
             Path to the Git repository.
 
         Returns
         -------
-        pull_requester : `neophile.pr.PullRequester`
+        PullRequester
             New pull requester.
         """
         return PullRequester(path, self._config, self._session)

--- a/src/neophile/inventory/github.py
+++ b/src/neophile/inventory/github.py
@@ -11,9 +11,7 @@ from gidgethub.aiohttp import GitHubAPI
 from ..config import Config
 from .version import PackagingVersion, ParsedVersion, SemanticVersion
 
-__all__ = [
-    "GitHubInventory",
-]
+__all__ = ["GitHubInventory"]
 
 
 class GitHubInventory:
@@ -41,22 +39,22 @@ class GitHubInventory:
 
         Parameters
         ----------
-        owner : `str`
+        owner
             Owner of the repository.
-        repo : `str`
+        repo
             Name of the repository.
-        semantic : `bool`, optional
+        semantic
             If set to true, only semantic versions will be considered and the
             latest version will be determined by semantic version sorting
             instead of `packaging.version.Version`.
 
         Returns
         -------
-        result : `str` or `None`
-            The latest tag in sorted order.  Tags that parse as valid versions
+        str or None
+            The latest tag in sorted order. Tags that parse as valid versions
             sort before tags that do not, which should normally produce the
-            correct results when version tags are mixed with other tags.  If
-            no valid tags are found or the repository doesn't exist, returns
+            correct results when version tags are mixed with other tags. If no
+            valid tags are found or the repository doesn't exist, returns
             `None`.
         """
         logging.info("Inventorying GitHub repo %s/%s", owner, repo)

--- a/src/neophile/inventory/helm.py
+++ b/src/neophile/inventory/helm.py
@@ -24,9 +24,8 @@ class HelmInventory:
 
     Parameters
     ----------
-    session : `aiohttp.ClientSession`
-        The aiohttp client session to use to make requests for Helm repository
-        index files.
+    session
+        Client session to use for requests for Helm repository index files.
     """
 
     def __init__(self, session: ClientSession) -> None:
@@ -38,12 +37,12 @@ class HelmInventory:
 
         Parameters
         ----------
-        url : `str`
+        url
             The URL for a Helm repository.
 
         Returns
         -------
-        canonical_url : `str`
+        str
             The canonical URL for the index.yaml file of the repository.
         """
         if url.endswith("/index.yaml"):
@@ -59,21 +58,23 @@ class HelmInventory:
 
         Parameters
         ----------
-        url : `str`
+        url
             URL of the repository.
 
         Returns
         -------
-        results : Dict[`str`, `str`]
-            Returns a dict of Helm chart names to the latest available version
-            of that Helm chart.
+        dict of str
+            Mapping of Helm chart names to the latest available version of
+            that Helm chart.
 
         Raises
         ------
         aiohttp.ClientError
-            Failure to retrieve the index file from the Helm repository.
+            Raised on failure to retrieve the index file from the Helm
+            repository.
         ruamel.yaml.YAMLError
-            The index file for the repository doesn't parse as YAML.
+            Raised if the index file for the repository doesn't parse as
+            YAML.
         """
         url = self.canonicalize_url(url)
         logging.info("Inventorying %s", url)
@@ -102,9 +103,8 @@ class CachedHelmInventory(HelmInventory):
 
     Parameters
     ----------
-    session : `aiohttp.ClientSession`
-        The aiohttp client session to use to make requests for Helm repository
-        index files.
+    session
+        Client session to use for requests for Helm repository index files.
     """
 
     _LIFETIME = 24 * 60 * 60
@@ -123,26 +123,23 @@ class CachedHelmInventory(HelmInventory):
 
         Parameters
         ----------
-        url : `str`
+        url
             URL of the repository.
 
         Returns
         -------
-        results : Dict[`str`, `str`]
-            Returns a dict of Helm chart names to the latest available version
-            of that Helm chart.
+        dict of str
+            Mapping of Helm chart names to the latest available version of
+            that Helm chart.
 
         Raises
         ------
         aiohttp.ClientError
-            Failure to retrieve the index file from the Helm repository.
+            Raised on failure to retrieve the index file from the Helm
+            repository.
         ruamel.yaml.YAMLError
-            The index file for the repository doesn't parse as YAML.
-
-        Notes
-        -----
-        This makes a copy of the contents of the cache to prevent the caller
-        from mutating the cache unexpectedly.
+            Raised if the index file for the repository doesn't parse as
+            YAML.
         """
         url = self.canonicalize_url(url)
         now = time.time()

--- a/src/neophile/inventory/version.py
+++ b/src/neophile/inventory/version.py
@@ -1,12 +1,4 @@
-"""Version representation for inventories.
-
-Notes
------
-This is a bit more complicated than it should have to be to work around
-https://github.com/python/mypy/issues/5374.  The mixins avoid the conflict
-between an abstract base class and a dataclass in mypy's understanding of the
-Python type system.
-"""
+"""Version representation for inventories."""
 
 from __future__ import annotations
 
@@ -40,13 +32,13 @@ class ParsedVersion(metaclass=ABCMeta):
 
         Parameters
         ----------
-        string : `str`
-            The version as a string.
+        string
+            Version as a string.
 
         Returns
         -------
-        version : `ParsedVersion`
-            The parsed version.
+        ParsedVersion
+            Parsed version.
         """
 
     @staticmethod
@@ -56,18 +48,18 @@ class ParsedVersion(metaclass=ABCMeta):
 
         Parameters
         ----------
-        string : `str`
-            The version as a string.
+        string
+            Version as a string.
 
         Returns
         -------
-        result : `bool`
+        bool
             Whether it is valid.
         """
 
     @abstractmethod
     def __str__(self) -> str:
-        """Return the original form of the version."""
+        """Original form of the version."""
 
 
 @dataclass(frozen=True, order=True)
@@ -93,13 +85,13 @@ class PackagingVersion(ParsedVersion):
 
         Parameters
         ----------
-        string : `str`
-            The version as a string.
+        string
+            Version as a string.
 
         Returns
         -------
-        version : `PackagingVersion`
-            The parsed version.
+        PackagingVersion
+            Parsed version.
         """
         parsed_version = version.parse(string)
         return cls(parsed_version=parsed_version, version=string)
@@ -110,14 +102,14 @@ class PackagingVersion(ParsedVersion):
 
         Parameters
         ----------
-        string : `str`
-            The version as a string.
+        string
+            Version as a string.
 
         Returns
         -------
-        result : `True`
-            All versions are valid for this implementation (some will parse to
-            a legacy version).
+        bool
+            Always returns `True` since all versions are valid for this
+            implementation (some will parse to a legacy version).
         """
         try:
             version.parse(string)
@@ -153,31 +145,19 @@ class SemanticVersion(ParsedVersion):
 
         Parameters
         ----------
-        string : `str`
-            The version as a string.
+        string
+            Version as a string.
 
         Returns
         -------
-        version : `SemanticVersion`
-            The parsed version.
+        SemanticVersion
+            Parsed version.
         """
         version = string[1:] if string.startswith("v") else string
         return cls(version=string, parsed_version=Version.parse(version))
 
     @staticmethod
     def is_valid(string: str) -> bool:
-        """Return whether a version is valid.
-
-        Parameters
-        ----------
-        string : `str`
-            The version as a string.
-
-        Returns
-        -------
-        result : `bool`
-            Whether the version is valid.
-        """
         version = string[1:] if string.startswith("v") else string
         return Version.is_valid(version)
 

--- a/src/neophile/pr.py
+++ b/src/neophile/pr.py
@@ -51,17 +51,17 @@ class CommitMessage:
     """A Git commit message."""
 
     changes: list[str]
-    """The changes represented by this commit."""
+    """Changes represented by this commit."""
 
     title: ClassVar[str] = "[neophile] Update dependencies"
-    """The title of the commit message, currently fixed for all commits."""
+    """Title of the commit message, currently fixed for all commits."""
 
     def __str__(self) -> str:
         return f"{self.title}\n\n{self.body}"
 
     @property
     def body(self) -> str:
-        """The body of the commit message."""
+        """Body of the commit message."""
         return "- " + "\n- ".join(self.changes) + "\n"
 
 
@@ -94,13 +94,13 @@ class PullRequester:
 
         Parameters
         ----------
-        changes : Sequence[`neophile.update.base.Update`]
+        changes
             The changes.
 
         Raises
         ------
-        neophile.exceptions.PushError
-            Pushing the branch to GitHub failed.
+        PushError
+            Raised if pushing the branch to GitHub failed.
         """
         github_repo = self._get_github_repo()
         default_branch = await self._get_github_default_branch(github_repo)
@@ -120,13 +120,13 @@ class PullRequester:
 
         Parameters
         ----------
-        changes : Sequence[`neophile.update.base.Update`]
+        changes
             The changes.
 
         Returns
         -------
-        message : `CommitMessage`
-            The corresponding commit message.
+        CommitMessage
+            Corresponding commit message.
         """
         descriptions = [change.description() for change in changes]
         return CommitMessage(changes=descriptions)
@@ -140,13 +140,13 @@ class PullRequester:
 
         Parameters
         ----------
-        changes : Sequence[`neophile.update.base.Update`]
-            The changes to apply and commit.
+        changes
+            Changes to apply and commit.
 
         Returns
         -------
-        message : `CommitMessage`
-            The commit message of the commit.
+        CommitMessage
+            Commit message of the commit.
         """
         actor = await self._get_github_actor()
         for change in changes:
@@ -165,12 +165,12 @@ class PullRequester:
 
         Parameters
         ----------
-        github_repo : `neophile.config.GitHubRepository`
+        github_repo
             GitHub repository in which to create the pull request.
-        base_branch : `str`
-            The branch of the repository to use as the base for the PR.
-        message : `CommitMessage`
-            The commit message to use for the pull request.
+        base_branch
+            Branch of the repository to use as the base for the PR.
+        message
+            Commit message to use for the pull request.
         """
         branch = self._repo.head.ref.name
         data = {
@@ -193,12 +193,14 @@ class PullRequester:
     ) -> None:
         """Enable automerge for a PR.
 
+        Failures are logged but do not raise an exception.
+
         Parameters
         ----------
-        github_repo : `neophile.config.GitHubRepository`
+        github_repo
             GitHub repository in which to create the pull request.
-        pr_number : `str`
-            The number of the PR in that repository to enable auto-merge for.
+        pr_number
+            Number of the PR in that repository to enable auto-merge for.
         """
         # Enabling auto-merge is only available via the GraphQL API with a
         # mutation.  To use that, we have to retrieve the GraphQL ID of the PR
@@ -229,8 +231,8 @@ class PullRequester:
 
         Returns
         -------
-        url : `str`
-            A URL suitable for an authenticated push of a new branch.
+        url
+            URL suitable for an authenticated push of a new branch.
         """
         url = self._get_remote_url()
         token = self._config.github_token.get_secret_value()
@@ -248,8 +250,8 @@ class PullRequester:
 
         Returns
         -------
-        author : `git.objects.util.Actor`
-            The actor to use for commits.
+        author
+            Actor to use for commits.
         """
         response = await self._github.getitem("/user")
         if self._config.github_email:
@@ -266,13 +268,13 @@ class PullRequester:
 
         Parameters
         ----------
-        github_repo : `neophile.config.GitHubRepository`
+        github_repo
             GitHub repository in which to create the pull request.
 
         Returns
         -------
-        branch : `str`
-            The name of the main branch.
+        str
+            Name of the main branch.
         """
         repo = await self._github.getitem(
             "/repos{/owner}{/repo}",
@@ -287,7 +289,7 @@ class PullRequester:
 
         Returns
         -------
-        repo : `neophile.config.GitHubRepository`
+        GitHubRepository
             GitHub repository information.
         """
         url = self._get_remote_url()
@@ -303,21 +305,21 @@ class PullRequester:
 
         Parameters
         ----------
-        github_repo : `neophile.config.GitHubRepository`
+        github_repo
             GitHub repository in which to search for a pull request.
-        bsae_branch : `str`
-            The base repository branch used to limit the search.
+        bsae_branch
+            Base repository branch used to limit the search.
 
         Returns
         -------
-        pr_number : `str` or `None`
-            The PR number or `None` if there is no open pull request from
+        str or None
+            PR number, or `None` if there is no open pull request from
             neophile.
 
         Notes
         -----
         The pull request is found by searching for all PRs in the open state
-        whose branch is u/neophile.
+        whose branch is ``u/neophile``.
         """
         query = {
             "state": "open",
@@ -341,8 +343,8 @@ class PullRequester:
 
         Returns
         -------
-        url : `str`
-            The results of `~urllib.parse.urlparse` on the origin remote URL.
+        url
+            Results of `~urllib.parse.urlparse` on the origin remote URL.
         """
         url = next(self._repo.remotes.origin.urls)
         if "//" in url:
@@ -352,12 +354,12 @@ class PullRequester:
             return urlparse(f"https://github.com/{path}")
 
     def _push_branch(self) -> None:
-        """Push the u/neophile branch to GitHub.
+        """Push the ``u/neophile`` branch to GitHub.
 
         Raises
         ------
-        neophile.exceptions.PushError
-            Pushing the branch to GitHub failed.
+        PushError
+            Raised if pushing the branch to GitHub failed.
         """
         branch = self._repo.head.ref.name
         remote_url = self._get_authenticated_remote()
@@ -381,12 +383,12 @@ class PullRequester:
 
         Parameters
         ----------
-        github_repo : `neophile.config.GitHubRepository`
+        github_repo
             GitHub repository in which to create the pull request.
-        pr_number : `str`
-            The number of the pull request to update.
-        message : `CommitMessage`
-            The commit message to use for the pull request.
+        pr_number
+            Number of the pull request to update.
+        message
+            Commit message to use for the pull request.
         """
         data = {
             "title": message.title,

--- a/src/neophile/processor.py
+++ b/src/neophile/processor.py
@@ -32,13 +32,14 @@ class Processor:
 
         Parameters
         ----------
-        path : `pathlib.Path`
+        path
             The path to the cloned repository.
 
         Returns
         -------
-        updates : Dict[`str`, List[`neophile.update.base.Update`]]
-            Any updates found, sorted by the analyzer that found the update.
+        dict of Update
+            Any updates found, organized by the analyzer that found the
+            update.
         """
         analyzers = self._factory.create_all_analyzers(path, use_venv=True)
         return {a.name: await a.analyze() for a in analyzers}
@@ -58,8 +59,8 @@ class Processor:
 
         Parameters
         ----------
-        path : `pathlib.Path`
-            The path to the cloned repository.
+        path
+            Path to the cloned repository.
         """
         repo = Repository(path)
         await self._process_one_repository(repo, path)
@@ -72,12 +73,12 @@ class Processor:
 
         Parameters
         ----------
-        path : `pathlib.Path`
-            The path to the cloned repository.
+        path
+            Path to the cloned repository.
 
         Returns
         -------
-        updates : List[`neophile.update.base.Update`]
+        list of Update
             All the updates that were applied.
         """
         analyzers = self._factory.create_all_analyzers(path, use_venv=True)
@@ -98,10 +99,10 @@ class Processor:
 
         Parameters
         ----------
-        repo : `neophile.repository.Repository`
-            The cloned repository to check.
-        path : `pathlib.Path`
-            The path to the cloned repository.
+        repo
+            Cloned repository to check.
+        path
+            Path to the cloned repository.
         """
         repo.switch_branch()
         updates = await self.update_checkout(path)

--- a/src/neophile/repository.py
+++ b/src/neophile/repository.py
@@ -15,7 +15,7 @@ class Repository:
 
     Parameters
     ----------
-    path : `str`
+    path
         Root path of the Git repository.
     """
 
@@ -25,14 +25,14 @@ class Repository:
 
         Parameters
         ----------
-        path : `pathlib.Path`
+        path
             Path to where the clone should be kept (and may already exist).
-        url : `str`
+        url
             URL of the remote repository.
 
         Returns
         -------
-        repo : `Repository`
+        Repository
             Newly-created repository object.
         """
         if path.is_dir():

--- a/src/neophile/scanner/helm.py
+++ b/src/neophile/scanner/helm.py
@@ -19,8 +19,8 @@ class HelmScanner(BaseScanner):
 
     Parameters
     ----------
-    root : `pathlib.Path`
-        The root of the source tree.
+    root
+        Root of the source tree.
     """
 
     def __init__(self, root: Path) -> None:
@@ -56,7 +56,7 @@ class HelmScanner(BaseScanner):
 
         Parameters
         ----------
-        path : `pathlib.Path`
+        path
             Path to the file containing the dependencies, either
             ``Chart.yaml`` (the new syntax) or ``requirements.yaml`` (the old
             syntax).

--- a/src/neophile/scanner/kustomize.py
+++ b/src/neophile/scanner/kustomize.py
@@ -24,7 +24,7 @@ class KustomizeScanner(BaseScanner):
 
     Parameters
     ----------
-    root : `pathlib.Path`
+    root
         The root of the source tree.
     """
 
@@ -72,7 +72,7 @@ class KustomizeScanner(BaseScanner):
 
         Parameters
         ----------
-        path : `pathlib.Path`
+        path
             Path to the ``kustomization.yaml`` file.
 
         Returns

--- a/src/neophile/scanner/pre_commit.py
+++ b/src/neophile/scanner/pre_commit.py
@@ -18,8 +18,8 @@ class PreCommitScanner(BaseScanner):
 
     Parameters
     ----------
-    root : `pathlib.Path`
-        The root of the source tree.
+    root
+        Root of the source tree.
     """
 
     def __init__(self, root: Path) -> None:

--- a/src/neophile/scanner/util.py
+++ b/src/neophile/scanner/util.py
@@ -16,15 +16,15 @@ def find_files(root: Path, wanted_names: set[str]) -> list[Path]:
 
     Parameters
     ----------
-    root : `pathlib.Path`
+    root
         The root from which to begin the search.
-    wanted_names : Set[`str`]
+    wanted_names
         The file names to search for.
 
     Returns
     -------
-    results : List[`pathlib.Path`]
-        A list of matching files.
+    list of pathlib.Path
+        List of matching files.
     """
     tests_path = root / "tests"
 

--- a/src/neophile/update/base.py
+++ b/src/neophile/update/base.py
@@ -31,7 +31,8 @@ class MethodMixin(ABC):
         Raises
         ------
         neophile.exceptions.DependencyNotFoundError
-            The specified file doesn't contain a dependency of that name.
+            Raised if the specified file doesn't contain a dependency of that
+            name.
         """
 
     @abstractmethod
@@ -40,7 +41,7 @@ class MethodMixin(ABC):
 
         Returns
         -------
-        description : `str`
+        str
             Short text description of the update.
         """
 
@@ -57,6 +58,11 @@ class UpdateMixin:
 
     def to_dict(self) -> dict[str, str | bool]:
         """Convert the object to a dict.
+
+        Returns
+        -------
+        dict of str or bool
+            Dictionary representation of this object.
 
         Notes
         -----

--- a/src/neophile/update/helm.py
+++ b/src/neophile/update/helm.py
@@ -31,8 +31,9 @@ class HelmUpdate(Update):
 
         Raises
         ------
-        neophile.exceptions.DependencyNotFoundError
-            The specified file doesn't contain a dependency of that name.
+        DependencyNotFoundError
+            Raised if the specified file doesn't contain a dependency of that
+            name.
         """
         if self.applied:
             return
@@ -56,13 +57,6 @@ class HelmUpdate(Update):
         self.applied = True
 
     def description(self) -> str:
-        """Build a description of this update.
-
-        Returns
-        -------
-        description : `str`
-            Short text description of the update.
-        """
         return (
             f"Update {self.name} Helm chart from {self.current}"
             f" to {self.latest}"

--- a/src/neophile/update/kustomize.py
+++ b/src/neophile/update/kustomize.py
@@ -38,8 +38,9 @@ class KustomizeUpdate(Update):
 
         Raises
         ------
-        neophile.exceptions.DependencyNotFoundError
-            The specified file doesn't contain a dependency of that name.
+        DependencyNotFoundError
+            Raised if the specified file doesn't contain a dependency of that
+            name.
         """
         if self.applied:
             return
@@ -68,13 +69,6 @@ class KustomizeUpdate(Update):
         self.applied = True
 
     def description(self) -> str:
-        """Build a description of this update.
-
-        Returns
-        -------
-        description : `str`
-            Short text description of the update.
-        """
         return (
             f"Update {self.owner}/{self.repo} Kustomize resource from"
             f" {self.current} to {self.latest}"

--- a/src/neophile/update/pre_commit.py
+++ b/src/neophile/update/pre_commit.py
@@ -32,8 +32,9 @@ class PreCommitUpdate(Update):
 
         Raises
         ------
-        neophile.exceptions.DependencyNotFoundError
-            The specified file doesn't contain a dependency of that name.
+        DependencyNotFoundError
+            Raised if the specified file doesn't contain a dependency of that
+            name.
         """
         if self.applied:
             return
@@ -58,13 +59,6 @@ class PreCommitUpdate(Update):
         self.applied = True
 
     def description(self) -> str:
-        """Build a description of this update.
-
-        Returns
-        -------
-        description : `str`
-            Short text description of the update.
-        """
         short_repo = urlparse(self.repository).path[1:]
         return (
             f"Update {short_repo} pre-commit hook from {self.current} to"

--- a/src/neophile/update/python.py
+++ b/src/neophile/update/python.py
@@ -29,7 +29,7 @@ class PythonFrozenUpdate(Update):
         Raises
         ------
         subprocess.CalledProcessError
-            Running ``make update-deps`` failed.
+            Raised if running ``make update-deps`` failed.
         """
         if self.applied:
             return
@@ -59,11 +59,4 @@ class PythonFrozenUpdate(Update):
         self.applied = True
 
     def description(self) -> str:
-        """Build a description of this update.
-
-        Returns
-        -------
-        description : `str`
-            Short text description of the update.
-        """
         return "Update frozen Python dependencies"

--- a/src/neophile/virtualenv.py
+++ b/src/neophile/virtualenv.py
@@ -18,13 +18,13 @@ class VirtualEnv:
 
     Python dependency updates using ``make update`` have to be done inside a
     virtual environment because they may attempt to install packages with
-    pip.  This class manages creation and execution of commands inside a
+    ``pip``. This class manages creation and execution of commands inside a
     virtual environment.
 
     Parameters
     ----------
-    path : `pathlib.Path`
-        Path to where to create the virtual environment.  If that directory
+    path
+        Path to where to create the virtual environment. If that directory
         already exists, it will be used as an existing virtual environment
         instead of creating a new one.
     """
@@ -38,8 +38,7 @@ class VirtualEnv:
         Raises
         ------
         subprocess.CalledProcessError
-            On failure to install the wheel package or if the command given
-            sets the ``check`` argument.
+            Raised on failure to install the wheel package.
         """
         if self._path.is_dir():
             return
@@ -60,22 +59,22 @@ class VirtualEnv:
 
         Parameters
         ----------
-        command : Sequence[`str`]
+        command
             The command to run.
-        **kwargs: `typing.Any`
+        **kwargs
             The arguments, which except for the ``env`` parameter if any will
-            be passed as-is to :py:func:`subprocess.run`.
+            be passed as-is to `subprocess.run`.
 
         Returns
         -------
-        result : `subprocess.CompletedProcess`
-            The return value of :py:func:`subprocess.run`.
+        subprocess.CompletedProcess
+            Return value of `subprocess.run`.
 
         Raises
         ------
         subprocess.CalledProcessError
-            On failure to install the wheel package or if the command given
-            sets the ``check`` argument.
+            Raised on failure to install the wheel package or failure of the
+            provided command.
         """
         self.create()
 
@@ -88,14 +87,14 @@ class VirtualEnv:
 
         Parameters
         ----------
-        env : Dict[`str`, `str`], optional
+        env
             The existing environment on which to base the new environment.
             If none is given, will use `os.environ` instead.
 
         Returns
         -------
-        env : Dict[`str`, `str`]
-            The environment to use when running commands in the virtualenv.
+        dict of str to str
+            Environment to use when running commands in the virtualenv.
         """
         env = dict(env) if env else dict(os.environ)
         env["PATH"] = str(self._path / "bin") + ":" + os.environ["PATH"]

--- a/tests/util.py
+++ b/tests/util.py
@@ -23,13 +23,13 @@ def dict_to_yaml(data: Mapping[str, Any]) -> str:
 
     Parameters
     ----------
-    data : Mapping[`str`, Any]
-        The data.
+    data
+        Data to convert.
 
     Returns
     -------
-    yaml : `str`
-        The data serialized as YAML.
+    str
+        Data serialized as YAML.
     """
     yaml = YAML()
     output = StringIO()
@@ -49,15 +49,15 @@ def mock_enable_auto_merge(
 
     Parameters
     ----------
-    mock : `aioresponses.aioresponses`
-        The mock object for aiohttp requests.
-    owner : `str`
+    mock
+        Mock object for aiohttp requests.
+    owner
         Owner of the repository.
-    repo : `str`
+    repo
         Name of the repository.
-    pr_number : `str`
+    pr_number
         Number of the PR for which auto-merge will be set.
-    fail : `bool`, optional
+    fail
         Whether to fail the request for automerge
     """
 
@@ -111,12 +111,12 @@ def register_mock_helm_repository(
 
     Parameters
     ----------
-    mock : `aioresponses.aioresponses`
-        The mock object for aiohttp requests.
-    url : `str`
-        The URL of the repository index.
-    versions : Mapping[`str`, Sequence[`str`]]
-        A mapping of Helm chart names to lists of version numbers that should
+    mock
+        Mock object for aiohttp requests.
+    url
+        URL of the repository index.
+    versions
+        Mapping of Helm chart names to lists of version numbers that should
         appear in the index for that chart.
     """
     data = {
@@ -135,12 +135,12 @@ def register_mock_github_tags(
 
     Parameters
     ----------
-    mock : `aioresponses.aioresponses`
-        The mock object for aiohttp requests.
-    repo : `str`
-        The name of the GitHub repository.
-    tags : Sequence[`str`]
-        The list of tags to return for that repository.
+    mock
+        Mock object for aiohttp requests.
+    repo
+        Name of the GitHub repository.
+    tags
+        List of tags to return for that repository.
     """
     data = [{"name": version} for version in tags]
     mock.get(
@@ -155,13 +155,13 @@ def setup_kubernetes_repo(tmp_path: Path) -> Repo:
 
     Parameters
     ----------
-    tmp_path : `pathlib.Path`
-        The directory in which to create the repository.
+    tmp_path
+        Directory in which to create the repository.
 
     Returns
     -------
-    repo : `git.Repo`
-        The repository object.
+    Repo
+        Repository object.
     """
     data_path = Path(__file__).parent / "data" / "kubernetes"
     shutil.copytree(str(data_path), str(tmp_path), dirs_exist_ok=True)
@@ -179,15 +179,15 @@ def setup_python_repo(tmp_path: Path, *, require_venv: bool = False) -> Repo:
 
     Parameters
     ----------
-    tmp_path : `pathlib.Path`
+    tmp_path
         The directory in which to create the repository.
-    require_venv : `bool`, optional
+    require_venv
         Whether ``make update-deps`` should fail if no virtualenv is in use.
 
     Returns
     -------
-    repo : `git.Repo`
-        The repository object.
+    Repo
+        Repository object.
     """
     data_path = Path(__file__).parent / "data" / "python"
     shutil.copytree(str(data_path), str(tmp_path), dirs_exist_ok=True)


### PR DESCRIPTION
Sphinx can now correctly pick up type information from the type annotations, so switch to the new docstring format that doesn't include redundant types. Take advantage of the opportunity to reword and improve some docstrings and remove some docstrings when the inherited ones would be fine.