### PR TITLE
DM-39519: Refactor factory and underlying objects

### DIFF
--- a/src/neophile/analysis/base.py
+++ b/src/neophile/analysis/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 from ..update.base import Update
 
@@ -13,11 +14,15 @@ class BaseAnalyzer(ABC):
     """Base class for an analysis step."""
 
     @abstractmethod
-    async def analyze(self, *, update: bool = False) -> list[Update]:
+    async def analyze(
+        self, root: Path, *, update: bool = False
+    ) -> list[Update]:
         """Analyze a tree and return a list of needed changes.
 
         Parameters
         ----------
+        root
+            Root of the path to analyze.
         update
             If set to `True`, leave the update applied if this is more
             efficient. Used by analyzers like the Python frozen dependency
@@ -40,7 +45,7 @@ class BaseAnalyzer(ABC):
         results accumulated from a bunch of analyzers.
         """
 
-    async def update(self) -> list[Update]:
+    async def update(self, root: Path) -> list[Update]:
         """Analyze a tree and apply updates.
 
         Returns
@@ -48,7 +53,7 @@ class BaseAnalyzer(ABC):
         list of Update
             List of updates applied.
         """
-        updates = await self.analyze(update=True)
+        updates = await self.analyze(root, update=True)
         for update in updates:
             update.apply()
         return updates

--- a/src/neophile/analysis/helm.py
+++ b/src/neophile/analysis/helm.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from ..inventory.helm import HelmInventory
 from ..inventory.version import SemanticVersion
@@ -40,11 +41,15 @@ class HelmAnalyzer(BaseAnalyzer):
         self._scanner = scanner
         self._inventory = inventory
 
-    async def analyze(self, *, update: bool = False) -> list[Update]:
+    async def analyze(
+        self, path: Path, *, update: bool = False
+    ) -> list[Update]:
         """Analyze a tree and return a list of needed Helm changes.
 
         Parameters
         ----------
+        root
+            Root of the path to analyze.
         update
             Ignored for this analyzer.
 
@@ -53,7 +58,7 @@ class HelmAnalyzer(BaseAnalyzer):
         list of Update
             List of needed updates.
         """
-        dependencies = self._scanner.scan()
+        dependencies = self._scanner.scan(path)
         repositories = {d.repository for d in dependencies}
         latest = {}
         for repo in repositories:

--- a/src/neophile/analysis/kustomize.py
+++ b/src/neophile/analysis/kustomize.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from ..inventory.github import GitHubInventory
 from ..scanner.kustomize import KustomizeScanner
 from ..update.base import Update
@@ -28,11 +30,15 @@ class KustomizeAnalyzer(BaseAnalyzer):
         self._scanner = scanner
         self._inventory = inventory
 
-    async def analyze(self, *, update: bool = False) -> list[Update]:
+    async def analyze(
+        self, root: Path, *, update: bool = False
+    ) -> list[Update]:
         """Analyze a tree and return a list of needed Kustomize changes.
 
         Parameters
         ----------
+        root
+            Root of the path to analyze.
         update
             Ignored for this analyzer.
 
@@ -41,7 +47,7 @@ class KustomizeAnalyzer(BaseAnalyzer):
         list of Update
             List of needed updates.
         """
-        dependencies = self._scanner.scan()
+        dependencies = self._scanner.scan(root)
 
         results: list[Update] = []
         for dependency in dependencies:

--- a/src/neophile/analysis/pre_commit.py
+++ b/src/neophile/analysis/pre_commit.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from ..inventory.github import GitHubInventory
 from ..scanner.pre_commit import PreCommitScanner
 from ..update.base import Update
@@ -28,11 +30,15 @@ class PreCommitAnalyzer(BaseAnalyzer):
         self._scanner = scanner
         self._inventory = inventory
 
-    async def analyze(self, *, update: bool = False) -> list[Update]:
+    async def analyze(
+        self, root: Path, *, update: bool = False
+    ) -> list[Update]:
         """Analyze a tree and return needed pre-commit hook changes.
 
         Parameters
         ----------
+        root
+            Root of the path to analyze.
         update
             Ignored for this analyzer.
 
@@ -41,7 +47,7 @@ class PreCommitAnalyzer(BaseAnalyzer):
         list of Update
             List of needed updates.
         """
-        dependencies = self._scanner.scan()
+        dependencies = self._scanner.scan(root)
 
         results: list[Update] = []
         for dependency in dependencies:

--- a/src/neophile/cli.py
+++ b/src/neophile/cli.py
@@ -15,7 +15,6 @@ from xdg import XDG_CONFIG_HOME
 from .config import Config
 from .factory import Factory
 from .inventory.github import GitHubInventory
-from .processor import Processor
 
 __all__ = ["main"]
 
@@ -103,7 +102,7 @@ async def analyze(
 
     async with aiohttp.ClientSession() as session:
         factory = Factory(config, session)
-        processor = Processor(config, factory)
+        processor = factory.create_processor()
         if pr:
             await processor.process_checkout(path)
         elif update:
@@ -155,7 +154,7 @@ async def process(ctx: click.Context) -> None:
     config = ctx.obj["config"]
     async with aiohttp.ClientSession() as session:
         factory = Factory(config, session)
-        processor = Processor(config, factory)
+        processor = factory.create_processor()
         await processor.process()
 
 
@@ -173,6 +172,6 @@ async def scan(ctx: click.Context, path: Path) -> None:
     config = ctx.obj["config"]
     async with aiohttp.ClientSession() as session:
         factory = Factory(config, session)
-        scanners = factory.create_all_scanners(path)
-        results = {s.name: s.scan() for s in scanners}
+        scanners = factory.create_all_scanners()
+        results = {s.name: s.scan(path) for s in scanners}
         print_yaml({k: [u.to_dict() for u in v] for k, v in results.items()})

--- a/src/neophile/scanner/base.py
+++ b/src/neophile/scanner/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from pathlib import Path
 
 from ..models.dependencies import Dependency
 
@@ -19,8 +20,13 @@ class BaseScanner(ABC):
         """Name of the scanner type."""
 
     @abstractmethod
-    def scan(self) -> Sequence[Dependency]:
+    def scan(self, root: Path) -> Sequence[Dependency]:
         """Scan a source tree for dependencies.
+
+        Parameters
+        ----------
+        root
+            Root of the source tree.
 
         Returns
         -------

--- a/src/neophile/scanner/helm.py
+++ b/src/neophile/scanner/helm.py
@@ -15,24 +15,22 @@ __all__ = ["HelmScanner"]
 
 
 class HelmScanner(BaseScanner):
-    """Scan a source tree for Helm version references.
+    """Scan a source tree for Helm version references."""
 
-    Parameters
-    ----------
-    root
-        Root of the source tree.
-    """
-
-    def __init__(self, root: Path) -> None:
-        self._root = root
+    def __init__(self) -> None:
         self._yaml = YAML()
 
     @property
     def name(self) -> str:
         return "helm"
 
-    def scan(self) -> list[HelmDependency]:
+    def scan(self, root: Path) -> list[HelmDependency]:
         """Scan a source tree for version references.
+
+        Parameters
+        ----------
+        root
+            Root of the source tree.
 
         Returns
         -------
@@ -40,7 +38,7 @@ class HelmScanner(BaseScanner):
             A list of all discovered dependencies.
         """
         wanted_files = {"Chart.yaml", "requirements.yaml"}
-        dependency_paths = find_files(self._root, wanted_files)
+        dependency_paths = find_files(root, wanted_files)
 
         results = []
         for path in dependency_paths:

--- a/src/neophile/scanner/kustomize.py
+++ b/src/neophile/scanner/kustomize.py
@@ -21,11 +21,6 @@ class KustomizeScanner(BaseScanner):
 
        github.com/<owner>/<repo>(.git)?//<path>?ref=<version>
        https://github.com/<owner>/<repo>/<path>?ref=<version>
-
-    Parameters
-    ----------
-    root
-        The root of the source tree.
     """
 
     RESOURCE_REGEXES = [
@@ -38,28 +33,30 @@ class KustomizeScanner(BaseScanner):
     will be the repository name, and the third match group will be the tag.
     """
 
-    def __init__(self, root: Path) -> None:
-        self._root = root
+    def __init__(self) -> None:
         self._yaml = YAML()
 
     @property
     def name(self) -> str:
         return "kustomize"
 
-    def scan(self) -> list[KustomizeDependency]:
+    def scan(self, root: Path) -> list[KustomizeDependency]:
         """Scan a source tree for version references.
+
+        Parameters
+        ----------
+        root
+            The root of the source tree.
 
         Returns
         -------
         list of KustomizeDependency
             A list of all discovered dependencies.
         """
-        dependency_paths = find_files(self._root, {"kustomization.yaml"})
-
+        dependency_paths = find_files(root, {"kustomization.yaml"})
         results = []
         for path in dependency_paths:
             results.extend(self._build_kustomize_dependencies(path))
-
         return results
 
     def _build_kustomize_dependencies(
@@ -81,7 +78,6 @@ class KustomizeScanner(BaseScanner):
             A list of all discovered Helm chart dependencies.
         """
         results = []
-
         with path.open() as f:
             kustomization = self._yaml.load(f)
         for resource in kustomization.get("resources", []):
@@ -99,5 +95,4 @@ class KustomizeScanner(BaseScanner):
                 path=path,
             )
             results.append(dependency)
-
         return results

--- a/src/neophile/scanner/pre_commit.py
+++ b/src/neophile/scanner/pre_commit.py
@@ -14,35 +14,33 @@ __all__ = ["PreCommitScanner"]
 
 
 class PreCommitScanner(BaseScanner):
-    """Scan a source tree for pre-commit hook version references.
+    """Scan a source tree for pre-commit hook version references."""
 
-    Parameters
-    ----------
-    root
-        Root of the source tree.
-    """
-
-    def __init__(self, root: Path) -> None:
-        self._root = root
+    def __init__(self) -> None:
         self._yaml = YAML()
 
     @property
     def name(self) -> str:
         return "pre-commit"
 
-    def scan(self) -> list[PreCommitDependency]:
+    def scan(self, root: Path) -> list[PreCommitDependency]:
         """Scan a source tree for pre-commit hook version references.
+
+        Parameters
+        ----------
+        root
+            Root of the source tree.
 
         Returns
         -------
         list of PreCommitDependency
             A list of all discovered pre-commit dependencies.
         """
-        path = self._root / ".pre-commit-config.yaml"
+        path = root / ".pre-commit-config.yaml"
         if not path.exists():
             return []
-        results = []
 
+        results = []
         with path.open() as f:
             config = self._yaml.load(f)
         for hook in config.get("repos", []):
@@ -55,5 +53,4 @@ class PreCommitScanner(BaseScanner):
                 path=path,
             )
             results.append(dependency)
-
         return results

--- a/tests/analysis/helm_test.py
+++ b/tests/analysis/helm_test.py
@@ -46,12 +46,12 @@ async def test_analyzer(session: ClientSession) -> None:
     with aioresponses() as mock:
         for url, index in MOCK_REPOSITORIES.items():
             mock.get(url, body=dict_to_yaml(index), repeat=True)
-        scanner = HelmScanner(data_path)
+        scanner = HelmScanner()
         inventory = HelmInventory(session)
         analyzer = HelmAnalyzer(scanner, inventory)
-        results = await analyzer.analyze()
+        results = await analyzer.analyze(data_path)
         analyzer = HelmAnalyzer(scanner, inventory, allow_expressions=True)
-        results_expressions = await analyzer.analyze()
+        results_expressions = await analyzer.analyze(data_path)
 
     assert sorted(results) == [
         HelmUpdate(

--- a/tests/analysis/kustomize_test.py
+++ b/tests/analysis/kustomize_test.py
@@ -27,8 +27,8 @@ async def test_analyzer(session: ClientSession) -> None:
             mock, "lsst-sqre", "sqrbot", ["20170114", "0.6.1", "0.7.0"]
         )
         factory = Factory(Config(), session)
-        analyzer = factory.create_kustomize_analyzer(data_path)
-        results = await analyzer.analyze()
+        analyzer = factory.create_kustomize_analyzer()
+        results = await analyzer.analyze(data_path)
 
     assert results == [
         KustomizeUpdate(
@@ -50,5 +50,5 @@ async def test_analyzer_missing(session: ClientSession) -> None:
 
     with aioresponses():
         factory = Factory(Config(), session)
-        analyzer = factory.create_kustomize_analyzer(data_path)
-        assert await analyzer.analyze() == []
+        analyzer = factory.create_kustomize_analyzer()
+        assert await analyzer.analyze(data_path) == []

--- a/tests/analysis/pre_commit_test.py
+++ b/tests/analysis/pre_commit_test.py
@@ -32,8 +32,8 @@ async def test_analyzer(session: ClientSession) -> None:
         register_mock_github_tags(mock, "ambv", "black", ["20.0.0", "19.10b0"])
         register_mock_github_tags(mock, "pycqa", "flake8", ["3.7.0", "3.9.0"])
         factory = Factory(Config(), session)
-        analyzer = factory.create_pre_commit_analyzer(data_path)
-        results = await analyzer.analyze()
+        analyzer = factory.create_pre_commit_analyzer()
+        results = await analyzer.analyze(data_path)
 
     pre_commit_path = data_path / ".pre-commit-config.yaml"
     assert results == [

--- a/tests/analysis/python_test.py
+++ b/tests/analysis/python_test.py
@@ -24,8 +24,8 @@ async def test_analyzer(tmp_path: Path, session: ClientSession) -> None:
     actor = Actor("Someone", "someone@example.com")
 
     factory = Factory(Config(), session)
-    analyzer = factory.create_python_analyzer(tmp_path)
-    results = await analyzer.analyze()
+    analyzer = factory.create_python_analyzer()
+    results = await analyzer.analyze(tmp_path)
 
     assert results == [
         PythonFrozenUpdate(path=tmp_path / "requirements", applied=False)
@@ -38,17 +38,17 @@ async def test_analyzer(tmp_path: Path, session: ClientSession) -> None:
     subprocess.run(["make", "update-deps"], cwd=str(tmp_path), check=True)
     assert repo.is_dirty()
     factory = Factory(Config(), session)
-    analyzer = factory.create_python_analyzer(tmp_path)
+    analyzer = factory.create_python_analyzer()
     with pytest.raises(UncommittedChangesError):
-        results = await analyzer.analyze()
+        results = await analyzer.analyze(tmp_path)
 
     # Commit the changed dependencies and remove the pre-commit configuration
     # file.  Analysis should now return no changes.
     repo.index.add(str(tmp_path / "requirements"))
     repo.index.commit("Update dependencies", author=actor, committer=actor)
     factory = Factory(Config(), session)
-    analyzer = factory.create_python_analyzer(tmp_path)
-    results = await analyzer.analyze()
+    analyzer = factory.create_python_analyzer()
+    results = await analyzer.analyze(tmp_path)
     assert results == []
 
 
@@ -57,8 +57,8 @@ async def test_analyzer_update(tmp_path: Path, session: ClientSession) -> None:
     repo = setup_python_repo(tmp_path)
 
     factory = Factory(Config(), session)
-    analyzer = factory.create_python_analyzer(tmp_path)
-    results = await analyzer.update()
+    analyzer = factory.create_python_analyzer()
+    results = await analyzer.update(tmp_path)
 
     assert results == [
         PythonFrozenUpdate(path=tmp_path / "requirements", applied=True)
@@ -73,6 +73,6 @@ async def test_virtualenv(
     setup_python_repo(tmp_path, require_venv=True)
 
     factory = Factory(Config(), session)
-    analyzer = factory.create_python_analyzer(tmp_path)
-    assert await analyzer.analyze() == []
+    analyzer = factory.create_python_analyzer()
+    assert await analyzer.analyze(tmp_path) == []
     assert "make update-deps failed" in caplog.records[0].msg

--- a/tests/processor_test.py
+++ b/tests/processor_test.py
@@ -22,7 +22,6 @@ from ruamel.yaml import YAML
 from neophile.config import Config, GitHubRepository
 from neophile.factory import Factory
 from neophile.pr import CommitMessage
-from neophile.processor import Processor
 
 from .util import (
     mock_enable_auto_merge,
@@ -140,7 +139,7 @@ async def test_processor(tmp_path: Path, session: ClientSession) -> None:
         # Unfortunately, the mock_push fixture can't be used here because we
         # want to use git.Remote.push in create_upstream_git_repository.
         factory = Factory(config, session)
-        processor = Processor(config, factory)
+        processor = factory.create_processor()
         with patch_clone_from("foo", "bar", upstream_path):
             with patch.object(Remote, "push") as mock_push:
                 mock_push.return_value = push_result
@@ -178,7 +177,7 @@ async def test_no_updates(tmp_path: Path, session: ClientSession) -> None:
     with aioresponses() as mock:
         mock.get("https://api.github.com/user", payload=user)
         factory = Factory(config, session)
-        processor = Processor(config, factory)
+        processor = factory.create_processor()
         with patch_clone_from("foo", "bar", upstream_path):
             with patch.object(Remote, "push") as mock_push:
                 await processor.process()
@@ -253,7 +252,7 @@ async def test_allow_expressions(
         # Unfortunately, the mock_push fixture can't be used here because we
         # want to use git.Remote.push in create_upstream_git_repository.
         factory = Factory(config, session)
-        processor = Processor(config, factory)
+        processor = factory.create_processor()
         with patch_clone_from("foo", "bar", upstream_path):
             with patch.object(Remote, "push") as mock_push:
                 mock_push.return_value = push_result

--- a/tests/scanner/helm_test.py
+++ b/tests/scanner/helm_test.py
@@ -10,8 +10,8 @@ from neophile.scanner.helm import HelmScanner
 
 def test_scanner() -> None:
     data_path = Path(__file__).parent.parent / "data" / "kubernetes"
-    scanner = HelmScanner(data_path)
-    results = scanner.scan()
+    scanner = HelmScanner()
+    results = scanner.scan(data_path)
 
     assert sorted(results, key=lambda r: r.name) == [
         HelmDependency(

--- a/tests/scanner/kustomize_test.py
+++ b/tests/scanner/kustomize_test.py
@@ -10,8 +10,8 @@ from neophile.scanner.kustomize import KustomizeScanner
 
 def test_scanner() -> None:
     data_path = Path(__file__).parent.parent / "data" / "kubernetes"
-    scanner = KustomizeScanner(data_path)
-    results = scanner.scan()
+    scanner = KustomizeScanner()
+    results = scanner.scan(data_path)
 
     assert sorted(results) == [
         KustomizeDependency(

--- a/tests/scanner/pre_commit_test.py
+++ b/tests/scanner/pre_commit_test.py
@@ -10,8 +10,8 @@ from neophile.scanner.pre_commit import PreCommitScanner
 
 def test_scanner() -> None:
     data_path = Path(__file__).parent.parent / "data" / "python"
-    scanner = PreCommitScanner(data_path)
-    results = scanner.scan()
+    scanner = PreCommitScanner()
+    results = scanner.scan(data_path)
 
     assert results == [
         PreCommitDependency(


### PR DESCRIPTION
Previously, the Factory object methods took a path to a package to analyze, and the Processor used the Factory to create other objects as needed. This was different than our other packages and a bit of an inversion of the factory pattern.

Instead, change the underlying objects to take the root of the directory to analyze or update as a parameter, make the factory methods take no parameters, and go back to having the factory create the processor object.