### PR TITLE
DM-39627: Allow specifying types of dependencies to analyze

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         args: [--allow-multiple-documents]
       - id: trailing-whitespace
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.272
     hooks:
       - id: ruff
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/asottile/blacken-docs
+  - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.13.0
     hooks:
       - id: blacken-docs

--- a/src/neophile/cli.py
+++ b/src/neophile/cli.py
@@ -67,6 +67,7 @@ def help(ctx: click.Context, topic: str | None) -> None:
 
 
 @main.command()
+@click.argument("types", type=click.Choice(["pre-commit", "python"]), nargs=-1)
 @click.option(
     "--path",
     type=click.Path(path_type=Path),
@@ -85,6 +86,7 @@ def help(ctx: click.Context, topic: str | None) -> None:
 @run_with_asyncio
 async def analyze(
     ctx: click.Context,
+    types: list[str],
     *,
     path: Path,
     pr: bool,
@@ -95,7 +97,7 @@ async def analyze(
 
     async with AsyncClient() as client:
         factory = Factory(config, client)
-        processor = factory.create_processor()
+        processor = factory.create_processor(types=types if types else None)
         if pr:
             await processor.process_checkout(path)
         elif update:

--- a/src/neophile/factory.py
+++ b/src/neophile/factory.py
@@ -33,20 +33,22 @@ class Factory:
         self._config = config
         self._http_client = http_client
 
-    def create_all_analyzers(
-        self, *, use_venv: bool = False
+    def create_analyzers(
+        self, types: list[str] | None = None, *, use_venv: bool = False
     ) -> list[BaseAnalyzer]:
         """Create all analyzers.
 
         Parameters
         ----------
+        types
+            If given, only create analyzers of the given types.
         use_venv
             Whether to use a virtualenv to isolate analysis.
 
         Returns
         -------
         list of BaseAnalyzer
-            List of all available analyzers.
+            List of analyzers.
 
         Notes
         -----
@@ -55,10 +57,15 @@ class Factory:
         analyzers are run in update mode (which means they will make changes
         to the working tree).
         """
-        return [
-            self.create_python_analyzer(use_venv=use_venv),
-            self.create_pre_commit_analyzer(),
-        ]
+        if not types:
+            types = ["python", "pre-commit"]
+
+        analyzers: list[BaseAnalyzer] = []
+        if "python" in types:
+            analyzers.append(self.create_python_analyzer(use_venv=use_venv))
+        if "pre-commit" in types:
+            analyzers.append(self.create_pre_commit_analyzer())
+        return analyzers
 
     def create_all_scanners(self) -> list[BaseScanner]:
         """Create all scanners.
@@ -103,13 +110,13 @@ class Factory:
         else:
             return PythonAnalyzer()
 
-    def create_processor(self) -> Processor:
+    def create_processor(self, types: list[str] | None = None) -> Processor:
         """Create a new repository processor.
 
         Parameters
         ----------
-        use_venv
-            Whether to use a virtualenv to isolate analysis.
+        types
+            If given, only process dependencies of the given types.
 
         Returns
         -------
@@ -118,7 +125,7 @@ class Factory:
         """
         return Processor(
             self._config,
-            self.create_all_analyzers(use_venv=True),
+            self.create_analyzers(types, use_venv=True),
             self.create_pull_requester(),
         )
 

--- a/src/neophile/inventory/github.py
+++ b/src/neophile/inventory/github.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from gidgethub import BadRequest
+from gidgethub import GitHubException
 from gidgethub.httpx import GitHubAPI
 from httpx import AsyncClient, HTTPError
 
@@ -73,7 +73,7 @@ class GitHubInventory:
                 async for tag in tags
                 if cls.is_valid(tag["name"])
             ]
-        except (BadRequest, HTTPError) as e:
+        except (GitHubException, HTTPError) as e:
             error = type(e).__name__
             if str(e):
                 error += f": {e!s}"

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -89,9 +89,7 @@ def test_analyze_update(tmp_path: Path, respx_mock: respx.Router) -> None:
     register_mock_github_tags(respx_mock, "pycqa", "flake8", ["3.8.1"])
 
     result = runner.invoke(
-        main,
-        ["analyze", "--path", str(tmp_path), "--update"],
-        env={"NEOPHILE_CACHE_ENABLED": "0"},
+        main, ["analyze", "--path", str(tmp_path), "--update", "pre-commit"]
     )
     assert result.exit_code == 0
     data = yaml.load(dst)


### PR DESCRIPTION
To more easily allow invoking neophile to manage only a specific type of dependency, add support for listing types of dependencies on the neophile analyze command line.

Report more gidgethub error messages.