### PR TITLE
DM-39627: Change analyze output and exit status

### DIFF
--- a/changelog.d/20230605_094239_rra_DM_39519.md
+++ b/changelog.d/20230605_094239_rra_DM_39519.md
@@ -1,4 +1,4 @@
 ### Other changes
 
-- Gafaelfawr now uses the [Ruff](https://beta.ruff.rs/docs/) linter instead of flake8 and isort.
+- neophile now uses the [Ruff](https://beta.ruff.rs/docs/) linter instead of flake8 and isort.
 - The neophile change log is now maintained using [scriv](https://scriv.readthedocs.io/).

--- a/changelog.d/20230612_103114_rra_DM_39627.md
+++ b/changelog.d/20230612_103114_rra_DM_39627.md
@@ -1,0 +1,11 @@
+### Backwards-incompatible changes
+
+- `neophile analyze` without the `--update` or `--pr` option now exits with non-zero status if any pending dependency updates are found.
+
+### New features
+
+- The types of dependencies to analyze may now be specified as command-line arguments to `neophile analyze`, rather than always analyzing every dependency type neophile knows about.
+
+### Bug fixes
+
+- `neophile analyze` now prints nothing if no pending updates were found, and omits dependency types with no pending updates from its output.

--- a/src/neophile/cli.py
+++ b/src/neophile/cli.py
@@ -104,9 +104,11 @@ async def analyze(
             await processor.update_checkout(path)
         else:
             results = await processor.analyze_checkout(path)
-            print_yaml(
-                {k: [u.to_dict() for u in v] for k, v in results.items()}
-            )
+            if results:
+                print_yaml(
+                    {k: [u.to_dict() for u in v] for k, v in results.items()}
+                )
+                sys.exit(1)
 
 
 @main.command()

--- a/src/neophile/processor.py
+++ b/src/neophile/processor.py
@@ -50,7 +50,12 @@ class Processor:
             Any updates found, organized by the analyzer that found the
             update.
         """
-        return {a.name: await a.analyze(path) for a in self._analyzers}
+        results = {}
+        for analyzer in self._analyzers:
+            analysis = await analyzer.analyze(path)
+            if analysis:
+                results[analyzer.name] = analysis
+        return results
 
     async def process(self) -> None:
         """Process all configured repositories for updates."""

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -60,13 +60,19 @@ def test_analyze(tmp_path: Path, respx_mock: respx.Router) -> None:
     register_mock_github_tags(respx_mock, "pycqa", "flake8", ["3.8.1"])
 
     result = runner.invoke(main, ["analyze", "--path", str(tmp_path)])
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     yaml = YAML()
     data = yaml.load(result.output)
     repository = "https://github.com/ambv/black"
     assert data["pre-commit"][0]["repository"] == repository
     assert data["pre-commit"][0]["current"] == "19.10b0"
     assert data["pre-commit"][0]["latest"] == "20.0.0"
+
+    # Try again with no changes required.
+    register_mock_github_tags(respx_mock, "ambv", "black", ["19.10b0"])
+    result = runner.invoke(main, ["analyze", "--path", str(tmp_path)])
+    assert not result.output
+    assert result.exit_code == 0
 
 
 def test_analyze_update(tmp_path: Path, respx_mock: respx.Router) -> None:


### PR DESCRIPTION
Stop printing any output from analyze if there are no detected dependency changes, and omit any dependencies with no detected updates. Exit non-zero if there are dependency changes and neither --update nor --pr were given.