### PR TITLE
DM-39627: Add a GitHub Actions check for dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,24 @@ jobs:
           python-version: ${{ matrix.python }}
           tox-envs: "py,coverage-report,typing"
 
+  dependencies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install neophile
+        run: make init
+
+      - name: Run neophile
+        run: neophile analyze python
+
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
         run: make init
 
       - name: Run neophile
-        run: neophile analyze python
+        run: neophile check python
 
   docs:
     runs-on: ubuntu-latest

--- a/changelog.d/20230612_103114_rra_DM_39627.md
+++ b/changelog.d/20230612_103114_rra_DM_39627.md
@@ -1,10 +1,11 @@
 ### Backwards-incompatible changes
 
-- `neophile analyze` without the `--update` or `--pr` option now exits with non-zero status if any pending dependency updates are found.
+- Add a new `neophile update` command that updates known dependencies in the provided tree and (if the `--pr` flag is given) creates a GitHub pull request. This replaces the `--update` and `--pr` flags to `neophile analyze`.
 
 ### New features
 
-- The types of dependencies to analyze may now be specified as command-line arguments to `neophile analyze`, rather than always analyzing every dependency type neophile knows about.
+- Add a new `neophile check` command that checks to see if all dependencies are up-to-date and exits with a non-zero status and messages to standard error if they are not. This is intended for use as a GitHub Actions check.
+- The types of dependencies to analyze may now be specified as command-line arguments to `neophile analyze` (and the new `neophile check` and `neophile update` commands). The default continues to be to analyze all known dependencies.
 
 ### Bug fixes
 

--- a/docs/user-guide/usage.rst
+++ b/docs/user-guide/usage.rst
@@ -16,7 +16,8 @@ neophile's processing is divided into five steps:
 #. **update**: Apply the changes found by analyze.
 #. **pull request**: Create a GitHub pull request.
 
-The primary command for command-line use is ``neophile analyze``, which will analyze the current working directory for out-of-date dependencies and produce either a report (the default), update those dependencies (``--update``), or create a GitHub pull request (``--pr``).
+The primary command for command-line use is ``neophile update``, which will analyze the current working directory for out-of-date dependencies and either update those dependencies (the default), or create a GitHub pull request (``--pr``).
+``neophile check`` checks whether dependencies are up-to-date and exits with a non-zero status if they are not.
 Other commands are provided to run only one of the above steps.
 
 The primary command when run as a cron job is ``neophile process``.

--- a/src/neophile/cli.py
+++ b/src/neophile/cli.py
@@ -74,14 +74,6 @@ def help(ctx: click.Context, topic: str | None) -> None:
     default=Path.cwd(),
     help="Path to analyze (default: current directory).",
 )
-@click.option(
-    "--pr/--no-pr", default=False, help="Generate a pull request of changes."
-)
-@click.option(
-    "--update/--no-update",
-    default=False,
-    help="Update out-of-date dependencies.",
-)
 @click.pass_context
 @run_with_asyncio
 async def analyze(
@@ -89,26 +81,44 @@ async def analyze(
     types: list[str],
     *,
     path: Path,
-    pr: bool,
-    update: bool,
 ) -> None:
     """Analyze a path for pending upgrades."""
     config = ctx.obj["config"]
-
     async with AsyncClient() as client:
         factory = Factory(config, client)
         processor = factory.create_processor(types=types if types else None)
-        if pr:
-            await processor.process_checkout(path)
-        elif update:
-            await processor.update_checkout(path)
-        else:
-            results = await processor.analyze_checkout(path)
-            if results:
-                print_yaml(
-                    {k: [u.to_dict() for u in v] for k, v in results.items()}
-                )
-                sys.exit(1)
+        results = await processor.analyze_checkout(path)
+        if results:
+            data = {k: [u.to_dict() for u in v] for k, v in results.items()}
+            print_yaml(data)
+
+
+@main.command()
+@click.argument("types", type=click.Choice(["pre-commit", "python"]), nargs=-1)
+@click.option(
+    "--path",
+    type=click.Path(path_type=Path),
+    default=Path.cwd(),
+    help="Path to analyze (default: current directory).",
+)
+@click.pass_context
+@run_with_asyncio
+async def check(
+    ctx: click.Context,
+    types: list[str],
+    *,
+    path: Path,
+) -> None:
+    """Check whether dependencies are up-to-date."""
+    config = ctx.obj["config"]
+    async with AsyncClient() as client:
+        factory = Factory(config, client)
+        processor = factory.create_processor(types=types if types else None)
+        results = await processor.analyze_checkout(path)
+        for dependency in results:
+            sys.stderr.write(f"{dependency} dependencies out of date\n")
+        if results:
+            sys.exit(1)
 
 
 @main.command()
@@ -158,3 +168,34 @@ async def scan(ctx: click.Context, path: Path) -> None:
         scanners = factory.create_all_scanners()
         results = {s.name: s.scan(path) for s in scanners}
         print_yaml({k: [u.to_dict() for u in v] for k, v in results.items()})
+
+
+@main.command()
+@click.argument("types", type=click.Choice(["pre-commit", "python"]), nargs=-1)
+@click.option(
+    "--path",
+    type=click.Path(path_type=Path),
+    default=Path.cwd(),
+    help="Path to analyze (default: current directory).",
+)
+@click.option(
+    "--pr/--no-pr", default=False, help="Generate a pull request of changes."
+)
+@click.pass_context
+@run_with_asyncio
+async def update(
+    ctx: click.Context,
+    types: list[str],
+    *,
+    path: Path,
+    pr: bool,
+) -> None:
+    """Update dependencies."""
+    config = ctx.obj["config"]
+    async with AsyncClient() as client:
+        factory = Factory(config, client)
+        processor = factory.create_processor(types=types if types else None)
+        if pr:
+            await processor.process_checkout(path)
+        else:
+            await processor.update_checkout(path)


### PR DESCRIPTION
On each pull request, check whether dependencies are up-to-date.

Rework the command line so that `neophile check` is suitable for this up-to-date check and the `--update` and `--pr` flags of `neophile analyze` are now implemented by a new `neophile update` command.