### PR TITLE
DM-39627: Redo how GitHub tokens are used

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,25 @@
+name: Dependency Update
+
+"on":
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install neophile
+        run: make init
+
+      - name: Run neophile
+        run: neophile update --pr pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.272
+    rev: v0.0.270
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/changelog.d/20230612_170105_rra_DM_39627.md
+++ b/changelog.d/20230612_170105_rra_DM_39627.md
@@ -1,0 +1,4 @@
+### Backwards-incompatible changes
+
+- neophile now gets the GitHub token to use for REST API requests from the `GITHUB_TOKEN` environment variable instead of `NEOPHILE_GITHUB_TOKEN`, thus allowing it to run from inside a GitHub Action.
+- When creating PRs, neophile no longer embeds the GitHub username and token in the remote URL. It instead uses the existing `origin` remote and assumes Git operations are already authenticated.

--- a/docs/user-guide/usage.rst
+++ b/docs/user-guide/usage.rst
@@ -60,7 +60,7 @@ At least ``github_user`` and ``github_token`` must be set.
     The email address to use for commits when pushing to GitHub.
     If not set, the default is the public email address of the configured GitHub user.
 
-``github_token`` (env: ``NEOPHILE_GITHUB_TOKEN``)
+``github_token`` (env: ``GITHUB_TOKEN``)
     A GitHub token.
     This must at least have ``public_repo`` access scope.
     neophile has only been tested with a `personal access token`_.

--- a/src/neophile/config.py
+++ b/src/neophile/config.py
@@ -32,11 +32,13 @@ class Config(BaseSettings):
     )
 
     github_token: SecretStr = Field(
-        SecretStr(""), description="GitHub token for creating pull requests"
+        SecretStr(""),
+        description="GitHub token for creating pull requests",
+        env="GITHUB_TOKEN",
     )
 
     github_user: str = Field(
-        "", description="GitHub user for creating pull requests"
+        "neophile", description="GitHub user for creating pull requests"
     )
 
     repositories: list[GitHubRepository] = Field(

--- a/tests/pr_test.py
+++ b/tests/pr_test.py
@@ -249,32 +249,6 @@ async def test_pr_update(
 
 
 @pytest.mark.asyncio
-async def test_get_authenticated_remote(
-    tmp_path: Path, client: AsyncClient
-) -> None:
-    repo = Repo.init(str(tmp_path), initial_branch="main")
-
-    config = Config(github_user="test", github_token=SecretStr("some-token"))
-    pr = PullRequester(config, client)
-
-    remote = Remote.create(repo, "origin", "https://github.com/foo/bar")
-    url = pr._get_authenticated_remote(repo)
-    assert url == "https://test:some-token@github.com/foo/bar"
-
-    remote.set_url("https://foo@github.com:8080/foo/bar")
-    url = pr._get_authenticated_remote(repo)
-    assert url == "https://test:some-token@github.com:8080/foo/bar"
-
-    remote.set_url("git@github.com:bar/foo")
-    url = pr._get_authenticated_remote(repo)
-    assert url == "https://test:some-token@github.com/bar/foo"
-
-    remote.set_url("ssh://git:blahblah@github.com/baz/stuff")
-    url = pr._get_authenticated_remote(repo)
-    assert url == "https://test:some-token@github.com/baz/stuff"
-
-
-@pytest.mark.asyncio
 async def test_get_github_repo(tmp_path: Path, client: AsyncClient) -> None:
     repo = Repo.init(str(tmp_path), initial_branch="main")
 


### PR DESCRIPTION
Stop embedding the GitHub token in the remote URL for Git repositories and instead assume Git actions will be authenticated externally somehow. Get the GitHub token for GitHub REST API operations from GITHUB_TOKEN instead of NEOPHILE_GITHUB_TOKEN so that it will work from inside GitHub Actions runs with the temporary token for the action.

Add a GitHub Actions job to update pre-commit dependencies using this new facility, and back down a pre-commit dependency so that it will have something to do.