### PR TITLE
DM-39627: Revert NEOPHILE_GITHUB_TOKEN change

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -23,3 +23,5 @@ jobs:
 
       - name: Run neophile
         run: neophile update --pr pre-commit
+        env:
+          NEOPHILE_GITNUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog.d/20230612_170105_rra_DM_39627.md
+++ b/changelog.d/20230612_170105_rra_DM_39627.md
@@ -1,4 +1,3 @@
 ### Backwards-incompatible changes
 
-- neophile now gets the GitHub token to use for REST API requests from the `GITHUB_TOKEN` environment variable instead of `NEOPHILE_GITHUB_TOKEN`, thus allowing it to run from inside a GitHub Action.
 - When creating PRs, neophile no longer embeds the GitHub username and token in the remote URL. It instead uses the existing `origin` remote and assumes Git operations are already authenticated.

--- a/src/neophile/config.py
+++ b/src/neophile/config.py
@@ -32,9 +32,7 @@ class Config(BaseSettings):
     )
 
     github_token: SecretStr = Field(
-        SecretStr(""),
-        description="GitHub token for creating pull requests",
-        env="GITHUB_TOKEN",
+        SecretStr(""), description="GitHub token for creating pull requests"
     )
 
     github_user: str = Field(


### PR DESCRIPTION
Go back to getting the GitHub token from NEOPHILE_GITHUB_TOKEN, since GitHub Actions creates a temporary secret, not an environment variable. Pass that secret to neophile via the environment in the dependency update workflow.