### PR TITLE
DM-39627: Redo GitHub actor handling for PRs

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -24,4 +24,5 @@ jobs:
       - name: Run neophile
         run: neophile update --pr pre-commit
         env:
+          NEOPHILE_GITHUB_EMAIL: "24442459+sqrbot@users.noreply.github.com"
           NEOPHILE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog.d/20230612_174406_rra_DM_39627.md
+++ b/changelog.d/20230612_174406_rra_DM_39627.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- If `NEOPHILE_GITHUB_EMAIL` is set in the environment, use it and the value of `NEOPHILE_GITHUB_USER` (`neophile` by default) as the actor for Git commits rather than querying the GitHub API for the name and email of the current user. This allows PR creation to be done from GitHub Actions workflows, where the `/user` endpoint is not available.

--- a/src/neophile/pr.py
+++ b/src/neophile/pr.py
@@ -246,10 +246,10 @@ class PullRequester:
         author
             Actor to use for commits.
         """
-        response = await self._github.getitem("/user")
         if self._config.github_email:
-            return Actor(response["name"], self._config.github_email)
+            return Actor(self._config.github_user, self._config.github_email)
         else:
+            response = await self._github.getitem("/user")
             return Actor(response["name"], response["email"])
 
     async def _get_github_default_branch(

--- a/tests/pr_test.py
+++ b/tests/pr_test.py
@@ -242,9 +242,9 @@ async def test_pr_update(
     assert not repo.is_dirty()
     assert repo.head.ref.name == "u/neophile"
     commit = repo.head.commit
-    assert commit.author.name == "Someone"
+    assert commit.author.name == "someone"
     assert commit.author.email == "otheremail@example.com"
-    assert commit.committer.name == "Someone"
+    assert commit.committer.name == "someone"
     assert commit.committer.email == "otheremail@example.com"
 
 


### PR DESCRIPTION
If NEOPHILE_GITHUB_EMAIL is set, do not try to use the /user endpoint to get the name and email address, and instead use that email address and NEOPHILE_GITHUB_USER (neophile by default) for the name portion. This allows PRs to be created by GitHub Actions, where the /user endpoint is not available.