### PR TITLE
DM-39627: Authenticate as a GitHub app

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -24,5 +24,6 @@ jobs:
       - name: Run neophile
         run: neophile update --pr pre-commit
         env:
-          NEOPHILE_GITHUB_EMAIL: "24442459+sqrbot@users.noreply.github.com"
-          NEOPHILE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEOPHILE_COMMIT_EMAIL: "24442459+sqrbot@users.noreply.github.com"
+          NEOPHILE_GITHUB_APP_ID: ${{ secrets.NEOPHILE_APP_ID }}
+          NEOPHILE_GITHUB_PRIVATE_KEY: ${{ secrets.NEOPHILE_PRIVATE_KEY }}

--- a/changelog.d/20230614_171744_rra_DM_39627.md
+++ b/changelog.d/20230614_171744_rra_DM_39627.md
@@ -1,0 +1,4 @@
+### Backwards-incompatible changes
+
+- When creating PRs, neophile now must be configured as a GitHub App with a suitable application ID and private key in environment variables.
+- Name and email address are now used only for Git commits, so the names of the environment variables to set them have changed accordingly to `NEOPHILE_COMMIT_NAME` and `NEOPHILE_COMMIT_EMAIL`.

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -34,6 +34,7 @@ python_api_dir = "dev/internals"
 rst_epilog_file = "_rst_epilog.rst"
 
 [sphinx.intersphinx.projects]
+git = "https://gitpython.readthedocs.io/en/stable/"
 packaging = "https://packaging.pypa.io/en/latest/"
 python = "https://docs.python.org/3/"
 semver = "https://python-semver.readthedocs.io/en/latest/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
+    "cryptography",
     "mypy",
     "pytest",
     "pytest-asyncio",

--- a/src/neophile/cli.py
+++ b/src/neophile/cli.py
@@ -11,7 +11,6 @@ from httpx import AsyncClient
 from ruamel.yaml import YAML
 from safir.asyncio import run_with_asyncio
 
-from .config import Config
 from .factory import Factory
 from .inventory.github import GitHubInventory
 
@@ -106,7 +105,7 @@ async def check(types: list[str], *, path: Path) -> None:
 async def github_inventory(owner: str, repo: str) -> None:
     """Inventory available GitHub tags."""
     async with AsyncClient() as client:
-        inventory = GitHubInventory(Config(), client)
+        inventory = GitHubInventory(client)
         result = await inventory.inventory(owner, repo)
         if result:
             sys.stdout.write(result + "\n")

--- a/src/neophile/config.py
+++ b/src/neophile/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from git.util import Actor
 from pydantic import BaseSettings, Field, SecretStr
 
 __all__ = ["Config"]
@@ -10,17 +11,24 @@ __all__ = ["Config"]
 class Config(BaseSettings):
     """Configuration for neophile."""
 
-    github_email: str | None = Field(
+    commit_name: str = Field(
+        "neophile", description="Name to use for GitHub commits"
+    )
+
+    commit_email: str | None = Field(
         None, description="Email address to use for GitHub commits"
     )
 
-    github_token: SecretStr = Field(
-        SecretStr(""), description="GitHub token for creating pull requests"
-    )
+    github_app_id: str = Field("", description="GitHub App ID")
 
-    github_user: str = Field(
-        "neophile", description="GitHub user for creating pull requests"
+    github_private_key: SecretStr = Field(
+        SecretStr(""), description="GitHub App private key"
     )
 
     class Config:
         env_prefix = "neophile_"
+
+    @property
+    def actor(self) -> Actor:
+        """Git actor to use for commits."""
+        return Actor(self.commit_name, self.commit_email)

--- a/src/neophile/factory.py
+++ b/src/neophile/factory.py
@@ -81,7 +81,7 @@ class Factory:
             New analyzer.
         """
         scanner = PreCommitScanner()
-        inventory = GitHubInventory(self._config, self._http_client)
+        inventory = GitHubInventory(self._http_client)
         return PreCommitAnalyzer(scanner, inventory)
 
     def create_python_analyzer(self) -> PythonAnalyzer:

--- a/src/neophile/inventory/github.py
+++ b/src/neophile/inventory/github.py
@@ -8,7 +8,6 @@ from gidgethub import GitHubException
 from gidgethub.httpx import GitHubAPI
 from httpx import AsyncClient, HTTPError
 
-from ..config import Config
 from .version import PackagingVersion, ParsedVersion, SemanticVersion
 
 __all__ = ["GitHubInventory"]
@@ -19,18 +18,12 @@ class GitHubInventory:
 
     Parameters
     ----------
-    config
-        neophile configuration.
     http_client
         HTTP client to use for requests.
     """
 
-    def __init__(self, config: Config, http_client: AsyncClient) -> None:
-        self._github = GitHubAPI(
-            http_client,
-            config.github_user,
-            oauth_token=config.github_token.get_secret_value(),
-        )
+    def __init__(self, http_client: AsyncClient) -> None:
+        self._github = GitHubAPI(http_client, "lsst-sqre/neophile")
 
     async def inventory(
         self, owner: str, repo: str, *, semantic: bool = False

--- a/tests/inventory/github_test.py
+++ b/tests/inventory/github_test.py
@@ -6,7 +6,6 @@ import pytest
 import respx
 from httpx import AsyncClient, Response
 
-from neophile.config import Config
 from neophile.inventory.github import GitHubInventory
 
 from ..support.github import mock_github_tags
@@ -25,7 +24,7 @@ async def test_inventory(
 
     for test in tests:
         mock_github_tags(respx_mock, "foo/bar", test["tags"])
-        inventory = GitHubInventory(Config(), client)
+        inventory = GitHubInventory(client)
         latest = await inventory.inventory("foo", "bar")
         assert latest == test["latest"]
 
@@ -37,7 +36,7 @@ async def test_inventory_semantic(
     tags = ["1.19.0", "1.18.0", "1.15.1", "20171120-1"]
 
     mock_github_tags(respx_mock, "foo/bar", tags)
-    inventory = GitHubInventory(Config(), client)
+    inventory = GitHubInventory(client)
     latest = await inventory.inventory("foo", "bar")
     assert latest == "20171120-1"
     latest = await inventory.inventory("foo", "bar", semantic=True)
@@ -53,6 +52,6 @@ async def test_inventory_missing(
     respx_mock.get("https://api.github.com/repos/foo/nonexistent/tags").mock(
         return_value=Response(404)
     )
-    inventory = GitHubInventory(Config(), client)
+    inventory = GitHubInventory(client)
     assert await inventory.inventory("foo", "bar") is None
     assert await inventory.inventory("foo", "nonexistent") is None

--- a/tests/support/github.py
+++ b/tests/support/github.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import Sequence
 from copy import deepcopy
 from pathlib import Path
@@ -16,10 +17,28 @@ from ruamel.yaml import YAML
 from neophile.pr import _GRAPHQL_ENABLE_AUTO_MERGE, _GRAPHQL_PR_ID
 
 __all__ = [
+    "mock_app_authenticate",
     "mock_enable_auto_merge",
     "mock_github_tags",
     "mock_github_tags_from_precommit",
 ]
+
+
+def mock_app_authenticate(respx_mock: respx.Router, slug: str) -> None:
+    """Set up mocks for the GitHub API calls used for app authentication.
+
+    Parameters
+    ----------
+    respx_mock
+        Mock object for HTTP requests.
+    slug
+        Slug for the GitHub repository.
+    """
+    url = f"https://api.github.com/repos/{slug}/installation"
+    respx_mock.get(url).mock(return_value=Response(200, json={"id": 1}))
+    url = "https://api.github.com/app/installations/1/access_tokens"
+    response = Response(200, json={"token": "ghs_" + os.urandom(16).hex()})
+    respx_mock.post(url).mock(return_value=response)
 
 
 def mock_enable_auto_merge(


### PR DESCRIPTION
Rather than using a personal access token, authenticate as a GitHub app, installed into the GitHub repository for which neophile is trying to create a PR. For GitHub tag inventory requests, use an anonymous client, since that should be public information.

This eliminates the last use of github_user as a username, so replace that configuration with commit_name and commit_email and clarify that they're only used for Git commits.

Update the periodic GitHub Action to update pre-commit dependencies to use the new neophile organization-wide GitHub app via organization secrets.