### PR TITLE
DM-39627: Add Slack notifications for periodic workflows

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -27,3 +27,13 @@ jobs:
           NEOPHILE_COMMIT_EMAIL: "24442459+sqrbot@users.noreply.github.com"
           NEOPHILE_GITHUB_APP_ID: ${{ secrets.NEOPHILE_APP_ID }}
           NEOPHILE_GITHUB_PRIVATE_KEY: ${{ secrets.NEOPHILE_PRIVATE_KEY }}
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic dependency update for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -8,6 +8,7 @@ name: Periodic CI
 "on":
   schedule:
     - cron: "0 12 * * 1"
+  workflow_dispatch: {}
 
 jobs:
   test:
@@ -28,6 +29,16 @@ jobs:
           python-version: ${{ matrix.python }}
           tox-envs: "lint,typing,py"
           use-cache: false
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic test for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}
 
   docs:
     runs-on: ubuntu-latest
@@ -52,6 +63,16 @@ jobs:
           tox-envs: "docs,docs-linkcheck"
           use-cache: false
 
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic documentation build for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}
+
   pypi:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -68,3 +89,13 @@ jobs:
           pypi-token: ""
           python-version: "3.11"
           upload: false
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic PyPI test for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}


### PR DESCRIPTION
Send a Slack notification if the periodic dependency update or tests failed.