### PR TITLE
DM-39627: Update development documentation

### DIFF
--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -1,4 +1,7 @@
 .. _mypy: https://www.mypy-lang.org/
 .. _pre-commit: https://pre-commit.com/
 .. _pytest: https://docs.pytest.org/en/latest/
+.. _Ruff: https://beta.ruff.rs/docs/
+.. _scriv: https://scriv.readthedocs.io/en/latest/
+.. _semver: https://semver.org/
 .. _tox: https://tox.wiki/en/latest/

--- a/docs/dev/development.rst
+++ b/docs/dev/development.rst
@@ -12,7 +12,7 @@ neophile is an open source package, meaning that you can contribute to neophile 
 Since neophile is intended for internal use by Rubin Observatory, community contributions can only be accepted if they align with Rubin Observatory's aims.
 For that reason, it's a good idea to propose changes with a new `GitHub issue`_ before investing time in making a pull request.
 
-neophile is developed by the LSST SQuaRE team.
+neophile is developed by the Rubin Observatory SQuaRE team.
 
 .. _GitHub issue: https://github.com/lsst-sqre/neophile/issues/new
 
@@ -43,14 +43,14 @@ Pre-commit hooks
 The pre-commit hooks, which are automatically installed by running the :command:`make init` command on :ref:`set up <dev-environment>`, ensure that files are valid and properly formatted.
 Some pre-commit hooks automatically reformat code:
 
-``seed-isort-config``
-    Adds configuration for isort to the :file:`pyproject.toml` file.
-
-``isort``
-    Automatically sorts imports in Python modules.
+``ruff``
+    Lint Python code and attempt to automatically fix some problems.
 
 ``black``
     Automatically formats Python code.
+
+``blacken-docs``
+    Automatically formats Python code in reStructuredText documentation and docstrings.
 
 When these hooks fail, your Git commit will be aborted.
 To proceed, stage the new modifications and proceed with your Git commit.
@@ -60,23 +60,30 @@ To proceed, stage the new modifications and proceed with your Git commit.
 Running tests
 =============
 
-One way to test the library is by running pytest_ from the root of the source repository:
+To test nephile, run tox_, which tests it the same way that the CI workflow does:
 
 .. code-block:: sh
 
-   pytest
+   tox run
 
-You can also run tox_, which tests the library the same way that the CI workflow does:
+To run the tests with coverage analysis and generate a report, run:
 
 .. code-block:: sh
 
-   tox
+   tox run -e py,coverage-report
 
 To see a listing of test environments, run:
 
 .. code-block:: sh
 
-   tox -av
+   tox list
+
+To run a specific test or list of tests, you can add test file names (and any other pytest_ options) after ``--`` when executing the ``py`` tox environment.
+For example:
+
+.. code-block:: sh
+
+   tox run -e py -- tests/handlers/api_tokens_test.py
 
 .. _dev-build-docs:
 
@@ -89,42 +96,42 @@ Documentation is built with Sphinx_:
 
 .. code-block:: sh
 
-   tox -e docs
+   tox run -e docs
 
 The build documentation is located in the :file:`docs/_build/html` directory.
+
+To check the documentation for broken links, run:
+
+.. code-block:: sh
+
+   tox run -e docs-linkcheck
 
 .. _dev-change-log:
 
 Updating the change log
 =======================
 
-Each pull request should update the change log (:file:`CHANGELOG.rst`).
-Add a description of new features and fixes as list items under a section at the top of the change log called "Unreleased:"
+neophile uses scriv_ to maintain its change log.
 
-.. code-block:: rst
+When preparing a pull request, run :command:`scriv create`.
+This will create a change log fragment in :file:`changelog.d`.
+Edit that fragment, removing the sections that do not apply and adding entries fo this pull request.
+You can pass the ``--edit`` flag to :command:`scriv create` to open the created fragment automatically in an editor.
 
-   Unreleased
-   ----------
+Change log entries use the following sections:
 
-   - Description of the feature or fix.
+- **Backward-incompatible changes**
+- **New features**
+- **Bug fixes**
+- **Other changes** (for minor, patch-level changes that are not bug fixes, such as logging formatting changes or updates to the documentation)
 
-If the next version is known (because neophile's main branch is being prepared for a new major or minor version), the section may contain that version information:
+These entries will eventually be cut and pasted into the release description for the next release, so the Markdown for the change descriptions must be compatible with GitHub's Markdown conventions for the release description.
+Specifically:
 
-.. code-block:: rst
-
-   X.Y.0 (unreleased)
-   ------------------
-
-   - Description of the feature or fix.
-
-If the exact version and release date is known (:doc:`because a release is being prepared <release>`), the section header is formatted as:
-
-.. code-block:: rst
-
-   X.Y.0 (YYYY-MM-DD)
-   ------------------
-
-   - Description of the feature or fix.
+- Each bullet point should be entirely on one line, even if it contains multiple sentences.
+  This is an exception to the normal documentation convention of a newline after each sentence.
+  Unfortunately, GitHub interprets those newlines as hard line breaks, so they would result in an ugly release description.
+- Avoid using too much complex markup, such as nested bullet lists, since the formatting in the GitHub release description may not be what you expect and manually editing it is tedious.
 
 .. _style-guide:
 
@@ -134,10 +141,16 @@ Style guide
 Code
 ----
 
+- neophile mostly follows the :sqr:`072` Python style guide, although the code layout does not match that document.
+
 - The code style follows :pep:`8`, though in practice lean on Black and isort to format the code for you.
 
 - Use :pep:`484` type annotations.
-  The ``tox -e typing`` test environment, which runs mypy_, ensures that the project's types are consistent.
+  The ``tox run -e typing`` test environment, which runs mypy_, ensures that the project's types are consistent.
+
+- neophile uses the Ruff_ linter with most checks enabled.
+  Try to avoid ``noqa`` markers except for issues that need to be fixed in the future.
+  Tests that generate false positives should normally be disabled, but if the lint error can be avoided with minor rewriting that doesn't make the code harder to read, prefer the rewriting.
 
 - Write tests for Pytest_.
 

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -4,6 +4,8 @@ Developer guide
 
 This part of neophiles's documentation contains some supplemental information primarily of interest to people doing development on neophile itself.
 
+The neophile code structure partly but not entirely follows the guidelines in :sqr:`072`.
+
 .. toctree::
    :caption: Guides
 

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -6,8 +6,10 @@ This page gives an overview of how neophile releases are made.
 This information is only useful for maintainers.
 
 neophile's releases are largely automated through GitHub Actions (see the `ci.yaml`_ workflow file for details).
-When a semantic version tag is pushed to GitHub, documentation is built and pushed `for each version <https://neophile.lsst.io/v/index.html>`__).
+When a semantic version tag is pushed to GitHub, `neophile is released to PyPI`_ with that version.
+Similarly, documentation is built and pushed `for each version <https://neophile.lsst.io/v/index.html>`__).
 
+.. _`neophile is released to PyPI`: https://pypi.org/project/neophile/
 .. _`ci.yaml`: https://github.com/lsst-sqre/neophile/blob/main/.github/workflows/ci.yaml
 
 .. _regular-release:
@@ -24,16 +26,33 @@ Release tags are semantic version identifiers following the :pep:`440` specifica
 1. Change log and documentation
 -------------------------------
 
-Each PR should include updates to the change log.
-If the change log or documentation needs additional updates, now is the time to make those changes through the regular branch-and-PR development method against the ``main`` branch.
+Change log messages for each release are accumulated using scriv_.
+See :ref:`dev-change-log` in the *Developer guide* for more details.
 
-In particular, replace the "Unreleased" section headline with the semantic version and date.
-See :ref:`dev-change-log` in the *Developer guide* for details.
+When it comes time to make the release, there should be a collection of change log fragments in :file:`changelog.d`.
+Those fragments will make up the change log for the new release.
+
+Review those fragments to determine the version number of the next release.
+neophile follows semver_, so follow its rules to pick the next version:
+
+- If there are any backward-incompatible changes, incremeent the major version number and set the other numbers to 0.
+- If there are any new features, increment the minor version number and set the patch version to 0.
+- Otherwise, increment the patch version number.
+
+Then, run ``scriv collect --version <version>`` specifying the version number you decided on.
+This will delete the fragment files and collect them into :file:`CHANGELOG.md` under an entry for the new release.
+Review that entry and edit it as needed (proofread, change the order to put more important things first, etc.).
+scriv will put blank lines between entries from different files.
+You may wish to remove those blank lines to ensure consistent formatting by various Markdown parsers.
+
+Finally, create a PR from those changes and merge it before continuing with the release process.
 
 2. Tag the release
 ------------------
 
-At the HEAD of the ``main`` branch, create and push a tag with the semantic version:
+Make sure you are on the ``main`` branch of your local checkout and you have updated with the merged PR from the previous step.
+
+Then, create and push a tag with the semantic version:
 
 .. code-block:: sh
 
@@ -45,7 +64,17 @@ In particular, **don't** prefix the tag with ``v``.
 
 .. _setuptools_scm: https://github.com/pypa/setuptools_scm
 
-The `ci.yaml`_ GitHub Actions workflow uploads the new release to PyPI and documentation to https://safir.lsst.io.
+The `ci.yaml`_ GitHub Actions workflow uploads the new release to PyPI and documentation to `neophile's home page <https://neophile.lsst.io>`__.
+
+3. Create a GitHub release
+--------------------------
+
+Add a new GitHub release for this version.
+The release title should be the same as the version number.
+
+Paste the contents of the :file:`CHANGELOG.md` entry for this release, without the initial heading specifying the version number and date.
+Adjust the heading depth of the subsections to use ``##`` instead of ``###`` to match the pull request summary.
+Then, press the :guilabel:`Generate release notes` button to include the GitHub-generated summary of pull requests.
 
 .. _backport-release:
 


### PR DESCRIPTION
Update the development documentation for tox 4, Ruff, and scriv, and mention that releases are now uploaded to PyPI.