### PR TITLE
DM-39919: Push Git branches using the installation token

### DIFF
--- a/changelog.d/20230707_085835_rra_DM_39919.md
+++ b/changelog.d/20230707_085835_rra_DM_39919.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Use the GitHub App installation token when pushing Git changes in preparation for creating a PR rather than using the default GitHub Actions token. If the branch was pushed with the GitHub Actions token, further GitHub Actions refuse to run on that branch to avoid creating a loop, but we need GitHub Actions to run so that the dependency update PR can be automerged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "GitPython",
-    "click",
+    "click!=8.1.4",  # see https://github.com/pallets/click/issues/2558
     "gidgethub",
     "httpx",
     "packaging",


### PR DESCRIPTION
Use the GitHub App installation token when pushing Git changes in preparation for creating a PR rather than using the default GitHub Actions token. If the branch was pushed with the GitHub Actions token, further GitHub Actions refuse to run on that branch to avoid creating a loop, but we need GitHub Actions to run so that the dependency update PR can be automerged.