### PR TITLE
DM-39919: Dynamically construct commit email address

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -24,7 +24,6 @@ jobs:
       - name: Run neophile
         run: neophile update --pr pre-commit
         env:
-          NEOPHILE_COMMIT_EMAIL: "24442459+sqrbot@users.noreply.github.com"
           NEOPHILE_GITHUB_APP_ID: ${{ secrets.NEOPHILE_APP_ID }}
           NEOPHILE_GITHUB_PRIVATE_KEY: ${{ secrets.NEOPHILE_PRIVATE_KEY }}
 

--- a/changelog.d/20230707_142506_rra_DM_39919.md
+++ b/changelog.d/20230707_142506_rra_DM_39919.md
@@ -1,0 +1,7 @@
+### Backwards-incompatible changes
+
+- The `NEOPHILE_COMMIT_NAME` environment variable is no longer supported. Instead, `NEOPHILE_USERNAME` configures the GitHub username of the running instantiation of neophile, used as both the name for Git commits and to construct the email address unless `NEOPHILE_COMMIT_EMAIL` is given. `NEOPHILE_USERNAME` defaults to `neophile-square[bot]`, the instantiation of neophile for the lsst-sqre organization.
+
+### New features
+
+- Setting `NEOPHILE_COMMIT_EMAIL` is now optional. If not set, the UID of the GitHub user from `NEOPHILE_USERNAME` is retrieved from the GitHub API and used to form a standard GitHub no-replay email address.

--- a/docs/user-guide/github-actions.rst
+++ b/docs/user-guide/github-actions.rst
@@ -83,7 +83,6 @@ Any package that uses pre-commit may wish to add the following workflow file, co
          - name: Run neophile
            run: neophile update --pr pre-commit
            env:
-             NEOPHILE_COMMIT_EMAIL: "24442459+sqrbot@users.noreply.github.com"
              NEOPHILE_GITHUB_APP_ID: ${{ secrets.NEOPHILE_APP_ID }}
              NEOPHILE_GITHUB_PRIVATE_KEY: ${{ secrets.NEOPHILE_PRIVATE_KEY }}
 
@@ -109,14 +108,14 @@ neophile configuration
 See :ref:`actions-setup` for more information.
 Two more environment variables may be set to customize neophile's behavior:
 
-``NEOPHILE_COMMIT_NAME`` (optional)
-    The name portion of the author and committer for the Git commit updating the dependencies.
-    If not set, defaults to ``neophile``.
-
-``NEOPHILE_COMMIT_EMAIL`` (required)
+``NEOPHILE_COMMIT_EMAIL`` (optional)
     The email address to use for the author and committer of the Git commit updating these dependencies.
-    The value shown in the example above is the GitHub email for the ``sqrbot`` user used by SQuaRE, and is an appropriate setting for SQuaRE-maintained packages.
-    For non-SQuaRE packages, set it to some appropriate value for your organization.
+    If this is not set, a standard GitHub email address will be derived from ``NEOPHILE_USERNAME``.
+
+``NEOPHILE_USERNAME`` (optional)
+    The GitHub username (``login``) of the GitHub App, used as the name portion of the author and committer for Git commits.
+    If ``NEOPHILE_COMMIT_EMAIL`` is not set, this is also used to retrieve the UID of this GitHub user and construct a standard GitHub email address to use for the commit.
+    If not set, defaults to ``neophile-square[bot]``.
 
 .. _slack-alerts:
 

--- a/src/neophile/config.py
+++ b/src/neophile/config.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from git.util import Actor
 from pydantic import BaseSettings, Field, SecretStr
 
 __all__ = ["Config"]
@@ -11,24 +10,29 @@ __all__ = ["Config"]
 class Config(BaseSettings):
     """Configuration for neophile."""
 
-    commit_name: str = Field(
-        "neophile", description="Name to use for GitHub commits"
-    )
-
-    commit_email: str | None = Field(
-        None, description="Email address to use for GitHub commits"
-    )
-
     github_app_id: str = Field("", description="GitHub App ID")
 
     github_private_key: SecretStr = Field(
         SecretStr(""), description="GitHub App private key"
     )
 
+    username: str = Field(
+        "neophile-square[bot]",
+        description=(
+            "Username, used as the name for GitHub commits and as part of"
+            " the email address if `commit_email` is not set. In the latter"
+            " case, must be the same as the login attribute in the GitHub"
+            " users API."
+        ),
+    )
+
+    commit_email: str | None = Field(
+        None,
+        description=(
+            "Email address to use for GitHub commits. If `None`, a GitHub"
+            " bot email address will be constructed using `github_app_id`."
+        ),
+    )
+
     class Config:
         env_prefix = "neophile_"
-
-    @property
-    def actor(self) -> Actor:
-        """Git actor to use for commits."""
-        return Actor(self.commit_name, self.commit_email)

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -161,8 +161,8 @@ def test_update_pr(
         data = yaml.load(dst)
         assert data["repos"][2]["rev"] == "20.0.0"
         commit = repo.head.commit
-        assert commit.author.name == "neophile"
-        assert commit.author.email == "neophile@example.com"
+        assert commit.author.name == "neophile-square[bot]"
+        assert commit.author.email == "someone@example.com"
         assert commit.message == f"{CommitMessage.title}\n\n- {change}\n"
 
         nonlocal created_pr
@@ -189,8 +189,8 @@ def test_update_pr(
         main,
         ["update", "--path", str(tmp_path), "--pr"],
         env={
+            "NEOPHILE_COMMIT_EMAIL": "someone@example.com",
             "NEOPHILE_GITHUB_PRIVATE_KEY": github_key,
-            "NEOPHILE_COMMIT_EMAIL": "neophile@example.com",
         },
     )
     assert result.exit_code == 0

--- a/tests/processor_test.py
+++ b/tests/processor_test.py
@@ -19,6 +19,7 @@ from httpx import AsyncClient, Request, Response
 from pydantic import SecretStr
 from ruamel.yaml import YAML
 
+from neophile.config import Config
 from neophile.factory import Factory
 from neophile.pr import CommitMessage
 
@@ -113,7 +114,7 @@ async def test_processor(
         data = yaml.load(tmp_path / "tmp" / ".pre-commit-config.yaml")
         assert data["repos"][2]["rev"] == "20.0.0"
         commit = repo.head.commit
-        assert commit.author.name == "neophile"
+        assert commit.author.name == "neophile-square[bot]"
         assert commit.author.email == "someone@example.com"
         assert commit.message == f"{CommitMessage.title}\n\n{body}"
 
@@ -142,8 +143,10 @@ async def test_processor(
     # Unfortunately, the mock_push fixture can't be used here because we
     # want to use git.Remote.push in create_upstream_git_repository.
     factory = Factory(client)
-    factory._config.commit_email = "someone@example.com"
-    factory._config.github_private_key = SecretStr(github_key)
+    factory._config = Config(
+        commit_email="someone@example.com",
+        github_private_key=SecretStr(github_key),
+    )
     processor = factory.create_processor()
     with patch_clone_from("foo", "bar", upstream_path):
         with patch.object(Remote, "push") as mock_push:


### PR DESCRIPTION
Remove the commit_name configuration option in favor of a username configuration option. Use it to construct a standard GitHub no-reply email address for that username if no email address was given, by retrieving the GitHub UID for that user and using it to create the standard GitHub email.