### PR TITLE
DM-39919: Pin Pydantic to 1.x versions

### DIFF
--- a/changelog.d/20230707_153200_rra_DM_39919.md
+++ b/changelog.d/20230707_153200_rra_DM_39919.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Pin Pydantic to version 1.x for now. neophile will require changes to work properly with Pydantic 2.x, which will be done after Safir adds support for it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "gidgethub",
     "httpx",
     "packaging",
-    "pydantic",
+    "pydantic<2",
     "ruamel.yaml",
     "safir",
     "semver",


### PR DESCRIPTION
neophile does not currently support Pydantic 2.x, and adding support when Safir doesn't support it is more likely to create than solve problems. Pin Pydantic to 1.x versions for now.