### PR TITLE
DM-39989: Use new lsst-sqre/build-and-publish-to-pypi Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,8 @@ name: CI
       - "renovate/**"
       - "tickets/**"
       - "u/**"
-    tags:
-      - "*"
+  release:
+    types: [published]
 
 jobs:
   lint:
@@ -25,13 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
 
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.0
 
   test:
     runs-on: ubuntu-latest
@@ -45,8 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Run tox
-        uses: lsst-sqre/run-tox@v1
+      - uses: lsst-sqre/run-tox@v1
         with:
           python-version: ${{ matrix.python }}
           tox-envs: "py,coverage-report,typing"
@@ -67,8 +64,7 @@ jobs:
       - name: Install extra packages
         run: sudo apt install -y graphviz
 
-      - name: Run tox
-        uses: lsst-sqre/run-tox@v1
+      - uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.11"
           tox-envs: "docs"
@@ -78,8 +74,7 @@ jobs:
       # releases, and pull requests from ticket branches.  This avoids version
       # clutter in the docs and failures when a PR doesn't have access to
       # secrets.
-      - name: Upload to LSST the Docs
-        uses: lsst-sqre/ltd-upload@v1
+      - uses: lsst-sqre/ltd-upload@v1
         with:
           project: neophile
           dir: "docs/_build/html"
@@ -90,10 +85,10 @@ jobs:
           && (github.event_name != 'pull_request'
               || startsWith(github.head_ref, 'tickets/'))
 
-  pypi:
+  test-packaging:
+    name: Test packaging
+    timeout-minutes: 5
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: [lint, test, docs]
 
     steps:
       - uses: actions/checkout@v3
@@ -101,8 +96,28 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Build and publish
-        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
-          pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
           python-version: "3.11"
-          upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+          upload: false
+
+  pypi:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [lint, test, docs, test-packaging]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/neophile
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
+
+      - uses: lsst-sqre/build-and-publish-to-pypi@v1
+        with:
+          python-version: "3.11"


### PR DESCRIPTION
Switch to the new version of lsst-sqre/build-and-publish-to-pypi, which uses trusted publishers and environments to authenticate to PyPI instead of using a PyPI token.

Remove some unnecessary names from GitHub actions steps.