### PR TITLE
Finish updating PyPI Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,6 +118,6 @@ jobs:
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - uses: lsst-sqre/build-and-publish-to-pypi@v1
+      - uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
           python-version: "3.11"

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -84,9 +84,8 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Build and publish
-        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
-          pypi-token: ""
           python-version: "3.11"
           upload: false
 


### PR DESCRIPTION
Bump the version of lsst-sqre/build-and-publish-to-pypi to v2 everywhere, fixing a previous oversight. Rename periodic.yaml to periodic-ci.yaml to match the templates.